### PR TITLE
Prepare v1.3.0 release

### DIFF
--- a/history.rst
+++ b/history.rst
@@ -1,6 +1,19 @@
 History
 =======
 
+1.3.0 (2026-05-29)
+------------------
+* Added support for categorical rasters as selectable A/B layers, including
+  categorical legends and disabled histogram states when categorical data cannot
+  be plotted as continuous values.
+* Fixed viewer startup compatibility with newer FastAPI/Starlette template
+  response handling and pinned the viewer Python dependency versions used by
+  the image build.
+* Fixed GeoServer initialization style configuration so the dynamic SLD path is
+  configurable via ``STYLE_PATH`` and mounted into ``geoserver-init``.
+* Improved local data directory compatibility in Docker Compose by supporting
+  both ``LOCAL_DATA`` and ``LOCAL_DATA_DIR`` environment variable names.
+
 1.2.0 (2026-03-20)
 ------------------
 * Added algorithm to pick no more than 1M pixels when determining histograms


### PR DESCRIPTION
## Summary
- Adds the `1.3.0 (2026-05-29)` section to `history.rst`.
- Documents categorical A/B layer support, viewer dependency/template compatibility fixes, and GeoServer init configuration fixes.

## Release Tag
Git tags are not part of the PR diff. After this PR is merged, create the release tag from an up-to-date `main` checkout:

```bash
git switch main
git pull --ff-only origin main
git tag -a v1.3.0 -m "v1.3.0"
git push origin v1.3.0
```

That makes `v1.3.0` point at the merged release commit on `main`.

Closes #168.

## Validation
- `git diff --check`