### PR TITLE
Show valid area summary stats in histogram overlay

### DIFF
--- a/app_rstats/main.py
+++ b/app_rstats/main.py
@@ -36,12 +36,13 @@ import tempfile
 import traceback
 import zipfile
 
+from affine import Affine
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from osgeo import gdal
 from pydantic import BaseModel
-from pyproj import Transformer
+from pyproj import Geod, Transformer
 from rasterio.errors import WindowError
 from rasterio.features import geometry_mask
 from rasterio.mask import mask as rio_mask
@@ -70,6 +71,9 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 logging.getLogger("rasterio").setLevel(logging.WARN)
+
+_GEOD = Geod(ellps="WGS84")
+_SQUARE_METERS_PER_HECTARE = 10_000.0
 
 
 class RasterMinMaxIn(BaseModel):
@@ -107,9 +111,10 @@ class GeometryScatterIn(BaseModel):
 
 
 class RasterSummary(BaseModel):
-    """Summary statistics for valid raster pixels."""
+    """Summary statistics for valid raster samples."""
 
     count: int
+    area_hectares: float
     sum: float
     mean: float
 
@@ -130,8 +135,8 @@ class ScatterOut(BaseModel):
         hist2d (Optional[List[List[int]]]): 2D histogram counts, or None if unavailable.
         x_edges (Optional[List[float]]): Bin edges for the X-axis histogram, or None if unavailable.
         y_edges (Optional[List[float]]): Bin edges for the Y-axis histogram, or None if unavailable.
-        x_summary (Optional[RasterSummary]): Valid-pixel summary for the X-axis raster.
-        y_summary (Optional[RasterSummary]): Valid-pixel summary for the Y-axis raster.
+        x_summary (Optional[RasterSummary]): Valid-value summary for the X-axis raster.
+        y_summary (Optional[RasterSummary]): Valid-value summary for the Y-axis raster.
         pearson_r (Optional[float]): Pearson correlation coefficient, or None if not computed.
         slope (Optional[float]): Linear regression slope (Y on X), or None if not computed.
         intercept (Optional[float]): Linear regression intercept, or None if not computed.
@@ -157,22 +162,75 @@ class ScatterOut(BaseModel):
     geometry: dict
 
 
-def summary_from_valid_values(vals: Optional[np.ndarray]) -> Optional[RasterSummary]:
+def valid_area_hectares(
+    valid_mask: np.ndarray,
+    affine: Affine,
+    raster_crs: rasterio.crs.CRS,
+) -> float:
+    """Estimate sampled valid raster area in hectares.
+
+    Args:
+        valid_mask: Boolean array where True marks finite, non-nodata sample
+            pixels inside the requested geometry.
+        affine: Affine transform for the sampled array.
+        raster_crs: Coordinate reference system for the sampled raster.
+
+    Returns:
+        Valid sampled area in hectares.
+    """
+
+    if raster_crs.is_projected:
+        unit_factor = raster_crs.linear_units_factor[1]
+        pixel_area = abs(affine.a * affine.e - affine.b * affine.d)
+        area_m2 = np.count_nonzero(valid_mask) * pixel_area * unit_factor**2
+        return float(area_m2 / _SQUARE_METERS_PER_HECTARE)
+
+    row_counts = np.count_nonzero(valid_mask, axis=1)
+    rows = np.flatnonzero(row_counts)
+    transformer_obj = None
+    if raster_crs.to_epsg() != 4326:
+        transformer_obj = Transformer.from_crs(
+            raster_crs, "EPSG:4326", always_xy=True
+        )
+
+    area_m2 = 0.0
+    for row_index in rows:
+        corners = [
+            affine * (0, row_index),
+            affine * (1, row_index),
+            affine * (1, row_index + 1),
+            affine * (0, row_index + 1),
+        ]
+        xs, ys = zip(*corners)
+        if transformer_obj is not None:
+            xs, ys = transformer_obj.transform(xs, ys)
+        cell_area_m2, _ = _GEOD.polygon_area_perimeter(xs, ys)
+        area_m2 += abs(cell_area_m2) * int(row_counts[row_index])
+
+    return float(area_m2 / _SQUARE_METERS_PER_HECTARE)
+
+
+def summary_from_valid_values(
+    vals: Optional[np.ndarray],
+    area_hectares: Optional[float],
+) -> Optional[RasterSummary]:
     """Compute compact summary statistics from valid raster values.
 
     Args:
         vals: One-dimensional array of finite raster values from the sampled
             geometry.
+        area_hectares: Area represented by finite, non-nodata sampled pixels.
 
     Returns:
-        Pixel count, sum, and mean for the sampled values, or None when no
-        valid values were read for the layer.
+        Area, pixel count, sum, and mean for the sampled values, or None when
+        no valid values were read for the layer.
     """
 
     if vals is None:
         return None
     return RasterSummary(
         count=int(vals.size),
+        area_hectares=float(area_hectares),
         sum=float(np.sum(vals)),
         mean=float(np.mean(vals)),
     )
@@ -783,6 +841,7 @@ def geometry_scatter(scatter_request: GeometryScatterIn):
                     "affine": None,
                     "hist": None,
                     "edges": None,
+                    "area_hectares": None,
                     "valid": False,
                 }
             ds = None
@@ -793,6 +852,7 @@ def geometry_scatter(scatter_request: GeometryScatterIn):
             affine = None
             hist = None
             edges = None
+            area_hectares = None
             valid = False
             try:
                 ds, nodata_val = _open_raster(raster_id)
@@ -807,7 +867,10 @@ def geometry_scatter(scatter_request: GeometryScatterIn):
                     boundless=True,
                     masked=False,
                 ).astype("float64", copy=False)
-                affine = ds.window_transform(win)
+                affine = ds.window_transform(win) * Affine.scale(
+                    win.width / out_w,
+                    win.height / out_h,
+                )
 
                 mask = geometry_mask(
                     [mapping(geom_ref_shape)],
@@ -821,10 +884,16 @@ def geometry_scatter(scatter_request: GeometryScatterIn):
                     data = np.where(np.isclose(data, nodata_val), np.nan, data)
 
                 arr = np.where(mask, data, np.nan)
-                vals = arr[np.isfinite(arr)]
+                valid_mask = np.isfinite(arr)
+                vals = arr[valid_mask]
 
                 if vals.size > 0:
                     hist, edges = np.histogram(vals, bins=bins)
+                    area_hectares = valid_area_hectares(
+                        valid_mask,
+                        affine,
+                        ds.crs,
+                    )
                     valid = True
             except ValueError as e:
                 logger.warning(f"{e} error on _read_clip_hist {raster_id}")
@@ -838,6 +907,7 @@ def geometry_scatter(scatter_request: GeometryScatterIn):
                 "affine": affine,
                 "hist": hist,
                 "edges": edges,
+                "area_hectares": area_hectares if valid else None,
                 "valid": valid,
             }
 
@@ -1004,8 +1074,14 @@ def geometry_scatter(scatter_request: GeometryScatterIn):
                 if results["y"]["hist"] is not None
                 else None
             ),
-            x_summary=summary_from_valid_values(results["x"]["vals"]),
-            y_summary=summary_from_valid_values(results["y"]["vals"]),
+            x_summary=summary_from_valid_values(
+                results["x"]["vals"],
+                results["x"]["area_hectares"],
+            ),
+            y_summary=summary_from_valid_values(
+                results["y"]["vals"],
+                results["y"]["area_hectares"],
+            ),
             geometry=scatter_request.geometry,
         )
 

--- a/app_rstats/main.py
+++ b/app_rstats/main.py
@@ -106,6 +106,14 @@ class GeometryScatterIn(BaseModel):
     all_touched: bool
 
 
+class RasterSummary(BaseModel):
+    """Summary statistics for valid raster pixels."""
+
+    count: int
+    sum: float
+    mean: float
+
+
 class ScatterOut(BaseModel):
     """Output model for scatterplot and histogram statistics between two raster layers.
 
@@ -122,6 +130,8 @@ class ScatterOut(BaseModel):
         hist2d (Optional[List[List[int]]]): 2D histogram counts, or None if unavailable.
         x_edges (Optional[List[float]]): Bin edges for the X-axis histogram, or None if unavailable.
         y_edges (Optional[List[float]]): Bin edges for the Y-axis histogram, or None if unavailable.
+        x_summary (Optional[RasterSummary]): Valid-pixel summary for the X-axis raster.
+        y_summary (Optional[RasterSummary]): Valid-pixel summary for the Y-axis raster.
         pearson_r (Optional[float]): Pearson correlation coefficient, or None if not computed.
         slope (Optional[float]): Linear regression slope (Y on X), or None if not computed.
         intercept (Optional[float]): Linear regression intercept, or None if not computed.
@@ -138,11 +148,34 @@ class ScatterOut(BaseModel):
     hist1d_y: Optional[List[int]] = None
     x_edges: Optional[List[float]] = None
     y_edges: Optional[List[float]] = None
+    x_summary: Optional[RasterSummary] = None
+    y_summary: Optional[RasterSummary] = None
     pearson_r: Optional[float] = None
     slope: Optional[float] = None
     intercept: Optional[float] = None
     valid_pixels: Optional[int] = None
     geometry: dict
+
+
+def summary_from_valid_values(vals: Optional[np.ndarray]) -> Optional[RasterSummary]:
+    """Compute compact summary statistics from valid raster values.
+
+    Args:
+        vals: One-dimensional array of finite raster values from the sampled
+            geometry.
+
+    Returns:
+        Pixel count, sum, and mean for the sampled values, or None when no
+        valid values were read for the layer.
+    """
+
+    if vals is None:
+        return None
+    return RasterSummary(
+        count=int(vals.size),
+        sum=float(np.sum(vals)),
+        mean=float(np.mean(vals)),
+    )
 
 
 class PixelValIn(BaseModel):
@@ -971,6 +1004,8 @@ def geometry_scatter(scatter_request: GeometryScatterIn):
                 if results["y"]["hist"] is not None
                 else None
             ),
+            x_summary=summary_from_valid_values(results["x"]["vals"]),
+            y_summary=summary_from_valid_values(results["y"]["vals"]),
             geometry=scatter_request.geometry,
         )
 

--- a/history.rst
+++ b/history.rst
@@ -3,8 +3,8 @@ History
 
 1.4.0 (2026-05-29)
 ------------------
-* Added valid-pixel count, sum, and average summaries beside histogram and
-  scatter plots for sampled continuous layers.
+* Added valid area, sum, and average summaries beside histogram and scatter
+  plots for sampled continuous layers.
 
 1.3.2 (2026-05-29)
 ------------------

--- a/history.rst
+++ b/history.rst
@@ -1,6 +1,11 @@
 History
 =======
 
+1.4.0 (2026-05-29)
+------------------
+* Added valid-pixel count, sum, and average summaries beside histogram and
+  scatter plots for sampled continuous layers.
+
 1.3.2 (2026-05-29)
 ------------------
 * Fixed categorical legends so labels are rendered from YAML metadata, preserving

--- a/static/app.js
+++ b/static/app.js
@@ -1968,11 +1968,10 @@ function formatSampleSummaryNumber(value) {
     return '-';
   }
   const absValue = Math.abs(value);
-  const options =
-    absValue >= 1_000_000 || (absValue > 0 && absValue < 0.001)
-      ? { maximumSignificantDigits: 5, notation: 'scientific' }
-      : { maximumSignificantDigits: 5 };
-  return new Intl.NumberFormat(undefined, options).format(value);
+  if (absValue >= 1_000_000 || (absValue > 0 && absValue < 0.001)) {
+    return value.toExponential(4);
+  }
+  return Number(value.toPrecision(5)).toString();
 }
 
 /**
@@ -1980,7 +1979,7 @@ function formatSampleSummaryNumber(value) {
  * @param {HTMLElement} container
  * @param {string} layerLabel
  * @param {string} rasterId
- * @param {{count:number,sum:number,mean:number}} summary
+ * @param {{area_hectares:number,sum:number,mean:number}} summary
  * @returns {void}
  */
 function appendSampleSummaryCard(container, layerLabel, rasterId, summary) {
@@ -1998,7 +1997,7 @@ function appendSampleSummaryCard(container, layerLabel, rasterId, summary) {
   card.appendChild(rasterName);
 
   [
-    ['Valid pixels', new Intl.NumberFormat().format(summary.count)],
+    ['Valid area', `${formatSampleSummaryNumber(summary.area_hectares)} ha`],
     ['Sum', formatSampleSummaryNumber(summary.sum)],
     ['Average', formatSampleSummaryNumber(summary.mean)],
   ].forEach(([labelText, valueText]) => {

--- a/static/app.js
+++ b/static/app.js
@@ -1959,6 +1959,100 @@ function enableAltWheelSlider() {
 }
 
 /**
+ * Format a sampled raster summary value for compact display.
+ * @param {number} value
+ * @returns {string}
+ */
+function formatSampleSummaryNumber(value) {
+  if (!Number.isFinite(value)) {
+    return '-';
+  }
+  const absValue = Math.abs(value);
+  const options =
+    absValue >= 1_000_000 || (absValue > 0 && absValue < 0.001)
+      ? { maximumSignificantDigits: 5, notation: 'scientific' }
+      : { maximumSignificantDigits: 5 };
+  return new Intl.NumberFormat(undefined, options).format(value);
+}
+
+/**
+ * Append a per-layer sampled raster summary card.
+ * @param {HTMLElement} container
+ * @param {string} layerLabel
+ * @param {string} rasterId
+ * @param {{count:number,sum:number,mean:number}} summary
+ * @returns {void}
+ */
+function appendSampleSummaryCard(container, layerLabel, rasterId, summary) {
+  const card = document.createElement('div');
+  card.className = 'sample-summary-card';
+
+  const title = document.createElement('div');
+  title.className = 'sample-summary-title';
+  title.textContent = layerLabel;
+  card.appendChild(title);
+
+  const rasterName = document.createElement('div');
+  rasterName.className = 'sample-summary-raster';
+  rasterName.textContent = rasterId;
+  card.appendChild(rasterName);
+
+  [
+    ['Valid pixels', new Intl.NumberFormat().format(summary.count)],
+    ['Sum', formatSampleSummaryNumber(summary.sum)],
+    ['Average', formatSampleSummaryNumber(summary.mean)],
+  ].forEach(([labelText, valueText]) => {
+    const row = document.createElement('div');
+    row.className = 'sample-summary-row';
+
+    const label = document.createElement('span');
+    label.className = 'sample-summary-label';
+    label.textContent = labelText;
+
+    const value = document.createElement('span');
+    value.className = 'sample-summary-value';
+    value.textContent = valueText;
+
+    row.append(label, value);
+    card.appendChild(row);
+  });
+
+  container.appendChild(card);
+}
+
+/**
+ * Render sampled raster summaries next to the active histogram or scatter plot.
+ * @param {Object|null} scatterObj
+ * @param {{rasterX:string,rasterY:string,visA:boolean,visB:boolean}} opts
+ * @returns {void}
+ */
+function renderSampleSummary(scatterObj, opts) {
+  const summaryEl = document.getElementById('sampleSummary');
+  if (!summaryEl) {
+    return;
+  }
+
+  summaryEl.replaceChildren();
+  if (!scatterObj) {
+    return;
+  }
+
+  if (opts.visA && scatterObj.x_summary) {
+    appendSampleSummaryCard(summaryEl, 'Layer A', opts.rasterX, scatterObj.x_summary);
+  }
+  if (opts.visB && scatterObj.y_summary) {
+    appendSampleSummaryCard(summaryEl, 'Layer B', opts.rasterY, scatterObj.y_summary);
+  }
+
+  if (!summaryEl.children.length) {
+    const empty = document.createElement('div');
+    empty.className = 'sample-summary-empty';
+    empty.textContent = 'No valid continuous pixels';
+    summaryEl.appendChild(empty);
+  }
+}
+
+/**
  * Render a scatterplot of two rasters' values within a polygon.
  * @param {{rasterX:string,rasterY:string,centerLng:number,centerLat:number,boxKm:number,scatterObj:object}} args
  */
@@ -2002,10 +2096,11 @@ async function renderScatterOverlay(opts) {
       </div>
 
       <div class='overlay-content'>
-        <div>
+        <div class='plot-report-layout'>
           <div id='scatterPlot' class='plot-holder'>
             ${hasData ? '' : '<div class="spinner" aria-label="loading"></div>'}
           </div>
+          <div id='sampleSummary' class='sample-summary'></div>
         </div>
         <div class='layer-group'>
           <label class='tool-label' for='percentiles'>Histogram Percentiles</label>
@@ -2033,12 +2128,14 @@ async function renderScatterOverlay(opts) {
   state.lastHasData = hasData;
 
   const plotEl = document.getElementById('scatterPlot');
+  const summaryEl = document.getElementById('sampleSummary');
   const plotRangeControls = document.getElementById('plotRangeControls');
 
   overlay.classList.remove('hidden');
 
   if (!visA && !visB) {
     plotEl.innerHTML = `<div class='no-layers-msg'><span>No layers selected</span></div>`;
+    summaryEl?.replaceChildren();
     plotRangeControls?.replaceChildren();
     return;
   }
@@ -2048,6 +2145,7 @@ async function renderScatterOverlay(opts) {
       plotEl.innerHTML =
         `<div class='no-layers-msg'><span>${histogramDisabledMessage}</span></div>`;
     }
+    summaryEl?.replaceChildren();
     plotRangeControls?.replaceChildren();
     return;
   }
@@ -2097,6 +2195,7 @@ async function renderScatterOverlay(opts) {
   state.scatterObj = scatterObj;
 
   plotEl.innerHTML = '';
+  renderSampleSummary(scatterObj, { rasterX, rasterY, visA, visB });
 
   let svg = null;
 

--- a/static/style.css
+++ b/static/style.css
@@ -382,7 +382,7 @@ input.num::-webkit-outer-spin-button {
     top: 12px;
     left: 12px;
     z-index: var(--z-overlay);
-    width: min(480px, calc(100% - 24px));
+    width: min(760px, calc(100% - 24px));
     max-height: calc(100% - 24px);
     background: rgba(var(--bg-rgb), 0.96);
     border: 1px solid var(--border);
@@ -471,6 +471,7 @@ input.num::-webkit-outer-spin-button {
 .overlay-content {
     display: grid;
     grid-template-columns: 1fr !important;
+    gap: var(--space-3);
 }
 
 .stats-grid {
@@ -498,14 +499,20 @@ input.num::-webkit-outer-spin-button {
 }
 
 .plot-report-layout {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(180px, 240px);
+    display: flex;
+    flex-wrap: wrap;
     gap: var(--space-3);
     align-items: start;
 }
 
+.plot-report-layout .plot-holder {
+    flex: 1 1 420px;
+    min-width: min(100%, 360px);
+}
+
 .sample-summary {
     display: grid;
+    flex: 0 1 260px;
     gap: var(--space-2);
     min-width: 0;
 }
@@ -577,8 +584,13 @@ input.num::-webkit-outer-spin-button {
 }
 
 @media (max-width: 760px) {
-    .plot-report-layout {
-        grid-template-columns: 1fr;
+    .plot-report-layout .plot-holder {
+        min-width: 0;
+    }
+
+    .sample-summary {
+        flex-basis: 100%;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -497,6 +497,67 @@ input.num::-webkit-outer-spin-button {
     overflow: hidden;
 }
 
+.plot-report-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(180px, 240px);
+    gap: var(--space-3);
+    align-items: start;
+}
+
+.sample-summary {
+    display: grid;
+    gap: var(--space-2);
+    min-width: 0;
+}
+
+.sample-summary-card,
+.sample-summary-empty {
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: rgba(15, 23, 42, 0.48);
+    padding: var(--space-2);
+}
+
+.sample-summary-title {
+    color: var(--text);
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+.sample-summary-raster {
+    color: var(--muted);
+    font-size: 11px;
+    line-height: 1.25;
+    margin: 2px 0 var(--space-2);
+    overflow-wrap: anywhere;
+}
+
+.sample-summary-row {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-2);
+    font-size: 12px;
+    line-height: 1.45;
+}
+
+.sample-summary-label {
+    color: var(--muted);
+}
+
+.sample-summary-value {
+    color: var(--text);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+    white-space: nowrap;
+}
+
+.sample-summary-empty {
+    color: var(--muted);
+    font-size: 12px;
+}
+
 #scatterPlot {
     display: flex;
     justify-content: center;
@@ -513,6 +574,12 @@ input.num::-webkit-outer-spin-button {
     stroke: rgba(0, 0, 0, 0.25);
     stroke-width: 0.3px;
     vector-effect: non-scaling-stroke;
+}
+
+@media (max-width: 760px) {
+    .plot-report-layout {
+        grid-template-columns: 1fr;
+    }
 }
 
 .spinner {


### PR DESCRIPTION
## Summary
- add valid area in hectares, sum, and average summaries to the `/stats/scatter` response for non-nodata sampled cells
- render compact per-layer summary cards beside the histogram/scatter plot in the viewer overlay
- widen the stats overlay and let the plot/report row wrap so the histogram keeps enough visual space on narrower screens
- compute geographic raster area geodesically by sampled row, and use projected pixel area for projected rasters
- update `history.rst` for the new user-facing feature

Closes #174.

## Validation
- `python -m py_compile app_rstats/main.py`
- `git diff --check`
- `node .\node_modules\vite\bin\vite.js build` from `static` using the bundled Node runtime