### PR TITLE
Show sample area percentages in summaries

### DIFF
--- a/app_rstats/main.py
+++ b/app_rstats/main.py
@@ -116,7 +116,7 @@ class RasterSummary(BaseModel):
 
     count: int
     area_hectares: float
-    area_fraction: float
+    area_percent: float
     sum: float
     mean: float
 
@@ -126,7 +126,7 @@ class CategoryAreaSummary(BaseModel):
 
     label: str
     area_hectares: float
-    area_fraction: float
+    area_percent: float
     color: Optional[str] = None
     opacity: Optional[float] = None
 
@@ -366,7 +366,7 @@ def categorical_area_summaries(
             color=meta["color"],
             opacity=meta["opacity"],
             area_hectares=group_areas[group_key],
-            area_fraction=group_areas[group_key] / sample_area_hectares,
+            area_percent=group_areas[group_key] / sample_area_hectares * 100.0,
         )
         for group_key, meta in group_meta.items()
         if group_areas.get(group_key, 0.0) > 0
@@ -396,7 +396,7 @@ def summary_from_valid_values(
     return RasterSummary(
         count=int(vals.size),
         area_hectares=float(area_hectares),
-        area_fraction=float(area_hectares / sample_area_hectares),
+        area_percent=float(area_hectares / sample_area_hectares * 100.0),
         sum=float(np.sum(vals)),
         mean=float(np.mean(vals)),
     )

--- a/app_rstats/main.py
+++ b/app_rstats/main.py
@@ -116,6 +116,7 @@ class RasterSummary(BaseModel):
 
     count: int
     area_hectares: float
+    area_fraction: float
     sum: float
     mean: float
 
@@ -125,6 +126,7 @@ class CategoryAreaSummary(BaseModel):
 
     label: str
     area_hectares: float
+    area_fraction: float
     color: Optional[str] = None
     opacity: Optional[float] = None
 
@@ -285,6 +287,7 @@ def categorical_area_summaries(
     affine: Affine,
     raster_crs: rasterio.crs.CRS,
     rendering: dict,
+    sample_area_hectares: float,
 ) -> list[CategoryAreaSummary]:
     """Aggregate sampled categorical raster area by configured legend item.
 
@@ -296,6 +299,7 @@ def categorical_area_summaries(
         affine: Affine transform for the sampled array.
         raster_crs: Coordinate reference system for the sampled raster.
         rendering: Layer rendering metadata from the YAML registry.
+        sample_area_hectares: Area represented by the sampled geometry.
 
     Returns:
         Category summaries in legend order, with duplicate raster codes
@@ -362,6 +366,7 @@ def categorical_area_summaries(
             color=meta["color"],
             opacity=meta["opacity"],
             area_hectares=group_areas[group_key],
+            area_fraction=group_areas[group_key] / sample_area_hectares,
         )
         for group_key, meta in group_meta.items()
         if group_areas.get(group_key, 0.0) > 0
@@ -371,6 +376,7 @@ def categorical_area_summaries(
 def summary_from_valid_values(
     vals: Optional[np.ndarray],
     area_hectares: Optional[float],
+    sample_area_hectares: Optional[float],
 ) -> Optional[RasterSummary]:
     """Compute compact summary statistics from valid raster values.
 
@@ -378,6 +384,7 @@ def summary_from_valid_values(
         vals: One-dimensional array of finite raster values from the sampled
             geometry.
         area_hectares: Area represented by finite, non-nodata sampled pixels.
+        sample_area_hectares: Area represented by the sampled geometry.
 
     Returns:
         Area, pixel count, sum, and mean for the sampled values, or None when
@@ -389,6 +396,7 @@ def summary_from_valid_values(
     return RasterSummary(
         count=int(vals.size),
         area_hectares=float(area_hectares),
+        area_fraction=float(area_hectares / sample_area_hectares),
         sum=float(np.sum(vals)),
         mean=float(np.mean(vals)),
     )
@@ -1000,6 +1008,7 @@ def geometry_scatter(scatter_request: GeometryScatterIn):
                     "hist": None,
                     "edges": None,
                     "area_hectares": None,
+                    "sample_area_hectares": None,
                     "categories": None,
                     "is_categorical": False,
                     "valid": False,
@@ -1013,6 +1022,7 @@ def geometry_scatter(scatter_request: GeometryScatterIn):
             hist = None
             edges = None
             area_hectares = None
+            sample_area_hectares = None
             category_summaries = None
             is_categorical = False
             valid = False
@@ -1057,6 +1067,11 @@ def geometry_scatter(scatter_request: GeometryScatterIn):
                 vals = arr[valid_mask]
 
                 if vals.size > 0:
+                    sample_area_hectares = valid_area_hectares(
+                        mask,
+                        affine,
+                        ds.crs,
+                    )
                     area_hectares = valid_area_hectares(
                         valid_mask,
                         affine,
@@ -1069,6 +1084,7 @@ def geometry_scatter(scatter_request: GeometryScatterIn):
                             affine,
                             ds.crs,
                             rendering,
+                            sample_area_hectares,
                         )
                     else:
                         hist, edges = np.histogram(vals, bins=bins)
@@ -1086,6 +1102,7 @@ def geometry_scatter(scatter_request: GeometryScatterIn):
                 "hist": hist,
                 "edges": edges,
                 "area_hectares": area_hectares if valid else None,
+                "sample_area_hectares": sample_area_hectares if valid else None,
                 "categories": category_summaries if valid else None,
                 "is_categorical": is_categorical,
                 "valid": valid,
@@ -1259,10 +1276,12 @@ def geometry_scatter(scatter_request: GeometryScatterIn):
             x_summary=summary_from_valid_values(
                 results["x"]["vals"] if x_hist_valid else None,
                 results["x"]["area_hectares"] if x_hist_valid else None,
+                results["x"]["sample_area_hectares"] if x_hist_valid else None,
             ),
             y_summary=summary_from_valid_values(
                 results["y"]["vals"] if y_hist_valid else None,
                 results["y"]["area_hectares"] if y_hist_valid else None,
+                results["y"]["sample_area_hectares"] if y_hist_valid else None,
             ),
             x_categories=results["x"]["categories"],
             y_categories=results["y"]["categories"],

--- a/history.rst
+++ b/history.rst
@@ -7,6 +7,7 @@ History
   plots for sampled continuous layers.
 * Added categorical sampled area summaries, grouped by configured legend item
   instead of raw raster code.
+* Added sampled-area percentages to continuous and categorical area summaries.
 
 1.3.2 (2026-05-29)
 ------------------

--- a/static/app.js
+++ b/static/app.js
@@ -1999,22 +1999,22 @@ function formatSampleSummaryNumber(value) {
 /**
  * Format a sampled area and its share of the sampled geometry.
  * @param {number} areaHectares
- * @param {number} areaFraction
+ * @param {number} areaPercent
  * @returns {string}
  */
-function formatSampleAreaWithPercent(areaHectares, areaFraction) {
+function formatSampleAreaWithPercent(areaHectares, areaPercent) {
   const areaText = `${formatSampleSummaryNumber(areaHectares)} ha`;
-  if (!Number.isFinite(areaFraction)) {
+  if (!Number.isFinite(areaPercent)) {
     return areaText;
   }
-  return `${areaText} (${(areaFraction * 100).toFixed(1)}%)`;
+  return `${areaText} (${areaPercent.toFixed(1)}%)`;
 }
 
 /**
  * Append a per-layer sampled raster summary card.
  * @param {HTMLElement} container
  * @param {string} rasterId
- * @param {{area_hectares:number,area_fraction:number,sum:number,mean:number}} summary
+ * @param {{area_hectares:number,area_percent:number,sum:number,mean:number}} summary
  * @returns {void}
  */
 function appendSampleSummaryCard(container, rasterId, summary) {
@@ -2028,8 +2028,8 @@ function appendSampleSummaryCard(container, rasterId, summary) {
 
   [
     [
-      'Valid area',
-      formatSampleAreaWithPercent(summary.area_hectares, summary.area_fraction),
+      'Valid area (% of sample)',
+      formatSampleAreaWithPercent(summary.area_hectares, summary.area_percent),
     ],
     ['Sum', formatSampleSummaryNumber(summary.sum)],
     ['Average', formatSampleSummaryNumber(summary.mean)],
@@ -2056,7 +2056,7 @@ function appendSampleSummaryCard(container, rasterId, summary) {
  * Append a sampled categorical area summary card.
  * @param {HTMLElement} container
  * @param {string} rasterId
- * @param {{label:string,color?:string,opacity?:number,area_hectares:number,area_fraction:number}[]} categories
+ * @param {{label:string,color?:string,opacity?:number,area_hectares:number,area_percent:number}[]} categories
  * @returns {void}
  */
 function appendCategoricalSummaryCard(container, rasterId, categories) {
@@ -2092,7 +2092,7 @@ function appendCategoricalSummaryCard(container, rasterId, categories) {
     value.className = 'sample-summary-value';
     value.textContent = formatSampleAreaWithPercent(
       category.area_hectares,
-      category.area_fraction,
+      category.area_percent,
     );
 
     nameWrap.append(swatch, label);

--- a/static/app.js
+++ b/static/app.js
@@ -1997,10 +1997,24 @@ function formatSampleSummaryNumber(value) {
 }
 
 /**
+ * Format a sampled area and its share of the sampled geometry.
+ * @param {number} areaHectares
+ * @param {number} areaFraction
+ * @returns {string}
+ */
+function formatSampleAreaWithPercent(areaHectares, areaFraction) {
+  const areaText = `${formatSampleSummaryNumber(areaHectares)} ha`;
+  if (!Number.isFinite(areaFraction)) {
+    return areaText;
+  }
+  return `${areaText} (${(areaFraction * 100).toFixed(1)}%)`;
+}
+
+/**
  * Append a per-layer sampled raster summary card.
  * @param {HTMLElement} container
  * @param {string} rasterId
- * @param {{area_hectares:number,sum:number,mean:number}} summary
+ * @param {{area_hectares:number,area_fraction:number,sum:number,mean:number}} summary
  * @returns {void}
  */
 function appendSampleSummaryCard(container, rasterId, summary) {
@@ -2013,7 +2027,10 @@ function appendSampleSummaryCard(container, rasterId, summary) {
   card.appendChild(title);
 
   [
-    ['Valid area', `${formatSampleSummaryNumber(summary.area_hectares)} ha`],
+    [
+      'Valid area',
+      formatSampleAreaWithPercent(summary.area_hectares, summary.area_fraction),
+    ],
     ['Sum', formatSampleSummaryNumber(summary.sum)],
     ['Average', formatSampleSummaryNumber(summary.mean)],
   ].forEach(([labelText, valueText]) => {
@@ -2039,7 +2056,7 @@ function appendSampleSummaryCard(container, rasterId, summary) {
  * Append a sampled categorical area summary card.
  * @param {HTMLElement} container
  * @param {string} rasterId
- * @param {{label:string,color?:string,opacity?:number,area_hectares:number}[]} categories
+ * @param {{label:string,color?:string,opacity?:number,area_hectares:number,area_fraction:number}[]} categories
  * @returns {void}
  */
 function appendCategoricalSummaryCard(container, rasterId, categories) {
@@ -2073,7 +2090,10 @@ function appendCategoricalSummaryCard(container, rasterId, categories) {
 
     const value = document.createElement('span');
     value.className = 'sample-summary-value';
-    value.textContent = `${formatSampleSummaryNumber(category.area_hectares)} ha`;
+    value.textContent = formatSampleAreaWithPercent(
+      category.area_hectares,
+      category.area_fraction,
+    );
 
     nameWrap.append(swatch, label);
     row.append(nameWrap, value);

--- a/static/style.css
+++ b/static/style.css
@@ -382,7 +382,7 @@ input.num::-webkit-outer-spin-button {
     top: 12px;
     left: 12px;
     z-index: var(--z-overlay);
-    width: min(760px, calc(100% - 24px));
+    width: min(960px, calc(100% - 24px));
     max-height: calc(100% - 24px);
     background: rgba(var(--bg-rgb), 0.96);
     border: 1px solid var(--border);
@@ -506,13 +506,13 @@ input.num::-webkit-outer-spin-button {
 }
 
 .plot-report-layout .plot-holder {
-    flex: 1 1 420px;
+    flex: 1 1 520px;
     min-width: min(100%, 360px);
 }
 
 .sample-summary {
     display: grid;
-    flex: 0 1 260px;
+    flex: 0 1 340px;
     gap: var(--space-2);
     min-width: 0;
 }
@@ -535,15 +535,17 @@ input.num::-webkit-outer-spin-button {
 }
 
 .sample-summary-row {
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: max-content minmax(0, 1fr);
     gap: var(--space-2);
+    align-items: baseline;
     font-size: 12px;
     line-height: 1.45;
 }
 
 .sample-summary-label {
     color: var(--muted);
+    white-space: nowrap;
 }
 
 .sample-summary-value {
@@ -626,6 +628,14 @@ input.num::-webkit-outer-spin-button {
     .sample-summary {
         flex-basis: 100%;
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    }
+
+    .sample-summary-row {
+        grid-template-columns: 1fr;
+    }
+
+    .sample-summary-label {
+        white-space: normal;
     }
 }
 


### PR DESCRIPTION
## Summary
- add `area_percent` values to continuous and categorical sampled summary API responses
- use the sampled geometry area as the denominator for area percentages
- render areas as `100 ha (40.0%)` with one decimal place in the percentage
- label the continuous row as `Valid area (% of sample)` for clarity
- widen the stats overlay and summary column so long labels and values do not wrap awkwardly
- update `history.rst`

Closes #180.

## Validation
- `python -m py_compile app_rstats/main.py`
- `git diff --check`
- `node .\node_modules\vite\bin\vite.js build` from `static` using the bundled Node runtime