### PR TITLE
Hide base-layer selector when no base layers exist

### DIFF
--- a/history.rst
+++ b/history.rst
@@ -7,6 +7,8 @@ History
   plots for sampled continuous layers.
 * Added categorical sampled area summaries, grouped by configured legend item
   instead of raw raster code.
+* Hid base-layer controls when the configuration does not define any base
+  layers.
 
 1.3.2 (2026-05-29)
 ------------------

--- a/static/app.js
+++ b/static/app.js
@@ -981,21 +981,38 @@ function populateLayerSelects() {
     sel.value = String(idx);
     sel.dispatchEvent(new Event("change", { bubbles: true }));
   });
-  ["Base"].forEach((layerId) => {
-    const sel = document.getElementById(`layerSelect${layerId}`);
-    fill(sel, state.availableBaseLayers);
 
-    const def = sel.dataset.default;
-    sel.addEventListener("change", (e) => onBaseLayerChange(e, layerId));
-    const idx = /^\d+$/.test(def)
-      ? parseInt(def, 10)
-      : state.availableBaseLayers.findIndex(
-          (l) => l.id === def || l.name === def,
-        );
-    if (idx < 0) return;
-    sel.value = String(idx);
-    sel.dispatchEvent(new Event("change", { bubbles: true }));
-  });
+  const baseGroup = document.getElementById("layerGroupBase");
+  const baseSelect = document.getElementById("layerSelectBase");
+  const hasBaseLayers = state.availableBaseLayers.length > 0;
+  baseGroup?.classList.toggle("hidden", !hasBaseLayers);
+
+  if (!hasBaseLayers) {
+    state.baseLayer = null;
+    state.activeBaseLayerIdx = null;
+    state.baseVisibility = false;
+    state.visibility.Base = false;
+    if (state.wmsLayerBase) {
+      state.map.removeLayer(state.wmsLayerBase);
+      state.wmsLayerBase = null;
+    }
+    renderLayerMeta("Base", null);
+    updateContextLegend();
+    return;
+  }
+
+  fill(baseSelect, state.availableBaseLayers);
+
+  const def = baseSelect.dataset.default;
+  baseSelect.addEventListener("change", onBaseLayerChange);
+  const idx = /^\d+$/.test(def)
+    ? parseInt(def, 10)
+    : state.availableBaseLayers.findIndex(
+        (l) => l.id === def || l.name === def,
+      );
+  if (idx < 0) return;
+  baseSelect.value = String(idx);
+  baseSelect.dispatchEvent(new Event("change", { bubbles: true }));
 }
 
 /**
@@ -1040,6 +1057,7 @@ function addWmsLayer(qualifiedName, slot, opts = {}) {
 function onBaseLayerChange(e) {
   const idx = parseInt(e.target.value, 10);
   const baseLayer = state.availableBaseLayers[idx];
+  if (!baseLayer) return;
   state.baseLayer = baseLayer;
   renderLayerMeta("Base", baseLayer);
 
@@ -4391,7 +4409,7 @@ function createBaseLegendControl() {
 
   state.geoserverBaseUrl = cfg.geoserver_base_url;
   state.availableLayers = cfg.layers;
-  state.availableBaseLayers = cfg.baseLayers;
+  state.availableBaseLayers = cfg.baseLayers || [];
   state.baseStatsUrl = cfg.rstats_base_url;
   ["A", "B"].forEach((layerId) => wireDynamicStyleControls(layerId));
   populateLayerSelects();

--- a/templates/index.html
+++ b/templates/index.html
@@ -63,7 +63,7 @@
         <div class="controls-bar">
           {% macro layer_group(layer_id, label_text, default_value='',
           show_checked=true) %}
-          <div class="layer-group">
+          <div id="layerGroup{{ layer_id }}" class="layer-group">
             <label class="layer-label">{{ label_text }}</label>
             <select
               id="layerSelect{{ layer_id }}"


### PR DESCRIPTION
## Summary
- hide the Base layer control group when config has no `baseLayers`
- avoid initializing or changing a base WMS layer when no base layer is configured
- keep base-layer state and legend state cleared in the no-base-layer case
- update `history.rst`

Closes #182.

## Validation
- `git diff --check`
- `node .\node_modules\vite\bin\vite.js build` from `static` using the bundled Node runtime