### PR TITLE
Add one-step raster COG build pipeline

### DIFF
--- a/history.rst
+++ b/history.rst
@@ -1,6 +1,12 @@
 History
 =======
 
+Unreleased
+----------
+* Added a one-step raster preparation utility that stitches country manifests,
+  converts outputs to COGs with dtype-aware overview resampling, and publishes
+  them directly to a GeoServer-ready directory.
+
 1.4.0 (2026-05-29)
 ------------------
 * Added valid area, sum, and average summaries beside histogram and scatter

--- a/history.rst
+++ b/history.rst
@@ -6,6 +6,8 @@ Unreleased
 * Added a one-step raster preparation utility that stitches country manifests,
   converts outputs to COGs with dtype-aware overview resampling, and publishes
   them directly to a GeoServer-ready directory.
+* Added configurable parallel COG conversion for the raster preparation
+  utility.
 
 1.4.0 (2026-05-29)
 ------------------

--- a/history.rst
+++ b/history.rst
@@ -10,6 +10,8 @@ Unreleased
   utility.
 * Added per-raster source/output nodata policies for the raster preparation
   utility so problematic nodata values can be normalized before stitching.
+* Expanded raster preparation nodata policies to support multiple source
+  nodata values for one raster.
 
 1.4.0 (2026-05-29)
 ------------------

--- a/history.rst
+++ b/history.rst
@@ -8,6 +8,8 @@ Unreleased
   them directly to a GeoServer-ready directory.
 * Added configurable parallel COG conversion for the raster preparation
   utility.
+* Added per-raster source/output nodata policies for the raster preparation
+  utility so problematic nodata values can be normalized before stitching.
 
 1.4.0 (2026-05-29)
 ------------------

--- a/history.rst
+++ b/history.rst
@@ -12,6 +12,8 @@ Unreleased
   utility so problematic nodata values can be normalized before stitching.
 * Expanded raster preparation nodata policies to support multiple source
   nodata values for one raster.
+* Fixed COG publication to preserve stitched raster nodata metadata instead of
+  overriding COG nodata independently of pixel values.
 
 1.4.0 (2026-05-29)
 ------------------

--- a/utils/build_country_cogs.py
+++ b/utils/build_country_cogs.py
@@ -14,6 +14,7 @@ This utility wraps the local raster preparation workflow:
 from __future__ import annotations
 
 import argparse
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import json
 import os
 from dataclasses import dataclass
@@ -156,6 +157,16 @@ def parse_args() -> argparse.Namespace:
         "--gdal-threads",
         default="1",
         help="NUM_THREADS creation option passed to gdal_translate.",
+    )
+    parser.add_argument(
+        "--cog-workers",
+        type=int,
+        default=min(4, os.cpu_count() or 1),
+        help=(
+            "Number of rasters to convert to COGs in parallel. Keep "
+            "--gdal-threads low when raising this to avoid oversubscribing "
+            "CPU and memory. Defaults to min(4, CPU count)."
+        ),
     )
     parser.add_argument(
         "--skip-stitch",
@@ -370,6 +381,34 @@ def progress_iter(items: Sequence[RasterJob], label: str) -> Iterator[RasterJob]
         yield from tqdm(items, desc=label, unit="raster")
 
 
+def progress_completed(
+    futures: dict, total: int, label: str
+) -> Iterator[tuple[RasterJob, object]]:
+    """Yield completed futures with tqdm-style progress output.
+
+    Args:
+        futures: Mapping of future objects to raster jobs.
+        total: Total number of futures.
+        label: Progress label.
+
+    Yields:
+        Raster jobs and future results in completion order.
+    """
+
+    try:
+        from tqdm import tqdm
+    except ImportError:
+        for index, future in enumerate(as_completed(futures), start=1):
+            job = futures[future]
+            result = future.result()
+            print(f"{label}: {index}/{total} {job.stitched_path.name}")
+            yield job, result
+    else:
+        for future in tqdm(as_completed(futures), total=total, desc=label, unit="raster"):
+            job = futures[future]
+            yield job, future.result()
+
+
 def inspect_jobs(gdalinfo_exe: str, jobs: Sequence[RasterJob]) -> list[RasterJob]:
     """Populate dtype and resampling for planned jobs.
 
@@ -482,6 +521,7 @@ def convert_jobs_to_cogs(
     compression: str,
     blocksize: str,
     gdal_threads: str,
+    cog_workers: int,
     dry_run: bool,
 ) -> None:
     """Convert all planned jobs to COGs.
@@ -494,20 +534,57 @@ def convert_jobs_to_cogs(
         compression: Compression creation option value.
         blocksize: Block size creation option value.
         gdal_threads: NUM_THREADS creation option value.
+        cog_workers: Number of COG conversions to run in parallel.
         dry_run: Whether to print without executing.
     """
 
-    for job in progress_iter(list(jobs), "Converting COGs"):
-        convert_to_cog(
-            gdal_translate_exe=gdal_translate_exe,
-            job=job,
-            nodata=nodata,
-            resampling_option=resampling_option,
-            compression=compression,
-            blocksize=blocksize,
-            gdal_threads=gdal_threads,
-            dry_run=dry_run,
-        )
+    if cog_workers <= 1 or dry_run:
+        for job in progress_iter(list(jobs), "Converting COGs"):
+            convert_to_cog(
+                gdal_translate_exe=gdal_translate_exe,
+                job=job,
+                nodata=nodata,
+                resampling_option=resampling_option,
+                compression=compression,
+                blocksize=blocksize,
+                gdal_threads=gdal_threads,
+                dry_run=dry_run,
+            )
+        return
+
+    with ThreadPoolExecutor(max_workers=cog_workers) as executor:
+        futures = {
+            executor.submit(
+                convert_to_cog,
+                gdal_translate_exe=gdal_translate_exe,
+                job=job,
+                nodata=nodata,
+                resampling_option=resampling_option,
+                compression=compression,
+                blocksize=blocksize,
+                gdal_threads=gdal_threads,
+                dry_run=dry_run,
+            ): job
+            for job in jobs
+        }
+        for _job, _result in progress_completed(
+            futures, total=len(futures), label="Converting COGs"
+        ):
+            pass
+
+
+def print_parallelism_note(cog_workers: int, gdal_threads: str) -> None:
+    """Print the configured COG conversion parallelism.
+
+    Args:
+        cog_workers: Number of COG conversion workers.
+        gdal_threads: NUM_THREADS value passed to each GDAL process.
+    """
+
+    print(
+        "COG conversion parallelism: "
+        f"{cog_workers} raster(s) at a time, GDAL NUM_THREADS={gdal_threads}"
+    )
 
 
 def check_executable(name: str) -> None:
@@ -585,6 +662,7 @@ def main() -> None:
     print(f"Found {len(manifest_paths)} manifest(s) in {manifest_dir}")
     print(f"Expected stitched rasters in {stitched_dir}")
     print(f"Publishing COGs to {publish_dir}")
+    print_parallelism_note(args.cog_workers, args.gdal_threads)
 
     if not args.skip_stitch:
         run_stitcher(
@@ -615,6 +693,7 @@ def main() -> None:
         compression=args.compression,
         blocksize=args.blocksize,
         gdal_threads=args.gdal_threads,
+        cog_workers=args.cog_workers,
         dry_run=args.dry_run,
     )
     print_summary(inspected_jobs)

--- a/utils/build_country_cogs.py
+++ b/utils/build_country_cogs.py
@@ -137,8 +137,8 @@ def parse_args() -> argparse.Namespace:
         "--nodata",
         default="0",
         help=(
-            "Nodata value passed to the stitcher and assigned to output COGs. "
-            "Use an empty string to skip -a_nodata during COG creation."
+            "Nodata value passed to the stitcher. Use an empty string to skip "
+            "passing --nodata to the stitcher."
         ),
     )
     parser.add_argument(
@@ -829,7 +829,6 @@ def ensure_stitched_outputs(jobs: Sequence[RasterJob]) -> None:
 def convert_to_cog(
     gdal_translate_exe: str,
     job: RasterJob,
-    nodata: str,
     resampling_option: str,
     compression: str,
     blocksize: str,
@@ -841,7 +840,6 @@ def convert_to_cog(
     Args:
         gdal_translate_exe: gdal_translate executable.
         job: Raster conversion job with dtype/resampling populated.
-        nodata: Nodata value assigned with -a_nodata, or empty string to skip.
         resampling_option: COG creation option name for overview resampling.
         compression: Compression creation option value.
         blocksize: Block size creation option value.
@@ -872,8 +870,6 @@ def convert_to_cog(
         "-co",
         f"NUM_THREADS={gdal_threads}",
     ]
-    if nodata != "":
-        command.extend(["-a_nodata", nodata])
 
     if dry_run:
         print(f"COG command: {format_command(command)}")
@@ -889,7 +885,6 @@ def convert_to_cog(
 def convert_jobs_to_cogs(
     gdal_translate_exe: str,
     jobs: Sequence[RasterJob],
-    nodata: str,
     resampling_option: str,
     compression: str,
     blocksize: str,
@@ -902,7 +897,6 @@ def convert_jobs_to_cogs(
     Args:
         gdal_translate_exe: gdal_translate executable.
         jobs: Raster jobs to convert.
-        nodata: Nodata value assigned with -a_nodata, or empty string to skip.
         resampling_option: COG creation option name for overview resampling.
         compression: Compression creation option value.
         blocksize: Block size creation option value.
@@ -916,7 +910,6 @@ def convert_jobs_to_cogs(
             convert_to_cog(
                 gdal_translate_exe=gdal_translate_exe,
                 job=job,
-                nodata=nodata,
                 resampling_option=resampling_option,
                 compression=compression,
                 blocksize=blocksize,
@@ -931,7 +924,6 @@ def convert_jobs_to_cogs(
                 convert_to_cog,
                 gdal_translate_exe=gdal_translate_exe,
                 job=job,
-                nodata=nodata,
                 resampling_option=resampling_option,
                 compression=compression,
                 blocksize=blocksize,
@@ -1084,7 +1076,6 @@ def main() -> None:
     convert_jobs_to_cogs(
         gdal_translate_exe=args.gdal_translate,
         jobs=inspected_jobs,
-        nodata=args.nodata,
         resampling_option=args.resampling_option,
         compression=args.compression,
         blocksize=args.blocksize,

--- a/utils/build_country_cogs.py
+++ b/utils/build_country_cogs.py
@@ -47,6 +47,22 @@ class RasterJob:
     resampling: str | None = None
 
 
+@dataclass(frozen=True)
+class NodataPolicy:
+    """Describes source-to-output nodata handling for one manifest.
+
+    Attributes:
+        raster_name: Manifest stem the policy applies to.
+        source_nodata: Value that should be treated as nodata before stitching.
+        output_nodata: Value that should be written as nodata for stitching and
+            COG publication.
+    """
+
+    raster_name: str
+    source_nodata: str
+    output_nodata: str
+
+
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments.
 
@@ -135,6 +151,32 @@ def parse_args() -> argparse.Namespace:
         help="gdalinfo executable to use for dtype inspection.",
     )
     parser.add_argument(
+        "--gdal-warp",
+        default="gdalwarp",
+        help="gdalwarp executable to use for nodata normalization.",
+    )
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Directory for temporary manifests and normalized nodata rasters. "
+            "Defaults to <manifest-dir>/_build_country_cogs."
+        ),
+    )
+    parser.add_argument(
+        "--nodata-policy",
+        action="append",
+        default=[],
+        metavar="NAME:SOURCE:OUTPUT",
+        help=(
+            "Per-raster nodata normalization applied before stitching. NAME "
+            "is the manifest stem without .txt, SOURCE is the value to treat "
+            "as nodata in source rasters, and OUTPUT is the nodata value to "
+            "write for stitching and COGs. Repeat for multiple rasters."
+        ),
+    )
+    parser.add_argument(
         "--resampling-option",
         default="RESAMPLING",
         help=(
@@ -203,6 +245,254 @@ def discover_manifests(manifest_dir: Path, manifest_glob: str) -> list[Path]:
     if not manifest_paths:
         raise RuntimeError(f"No manifests matched {manifest_glob!r} in {manifest_dir}")
     return manifest_paths
+
+
+def parse_nodata_policies(policy_values: Sequence[str]) -> dict[str, NodataPolicy]:
+    """Parse per-raster nodata policy CLI values.
+
+    Args:
+        policy_values: Values formatted as NAME:SOURCE:OUTPUT.
+
+    Returns:
+        Mapping of manifest stem to nodata policy.
+
+    Raises:
+        ValueError: If a policy value does not have exactly three parts.
+    """
+
+    policies = {}
+    for policy_value in policy_values:
+        parts = policy_value.split(":")
+        if len(parts) != 3:
+            raise ValueError(
+                "Nodata policies must use NAME:SOURCE:OUTPUT format. "
+                f"Got: {policy_value}"
+            )
+        raster_name, source_nodata, output_nodata = parts
+        policies[raster_name] = NodataPolicy(
+            raster_name=raster_name,
+            source_nodata=source_nodata,
+            output_nodata=output_nodata,
+        )
+    return policies
+
+
+def read_manifest_sources(manifest_path: Path) -> list[Path]:
+    """Read source raster paths from a stitch manifest.
+
+    Args:
+        manifest_path: Text file with one source raster path per line.
+
+    Returns:
+        Source raster paths listed in the manifest.
+    """
+
+    return [
+        Path(line.strip())
+        for line in manifest_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def write_manifest(manifest_path: Path, source_paths: Sequence[Path]) -> None:
+    """Write a stitch manifest.
+
+    Args:
+        manifest_path: Destination manifest path.
+        source_paths: Source raster paths to write.
+    """
+
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        "\n".join(str(path) for path in source_paths) + "\n",
+        encoding="utf-8",
+    )
+
+
+def normalized_source_path(
+    source_path: Path, policy: NodataPolicy, output_dir: Path, index: int
+) -> Path:
+    """Build a deterministic path for a normalized source raster.
+
+    Args:
+        source_path: Original source raster path.
+        policy: Nodata policy being applied.
+        output_dir: Directory for normalized sources.
+        index: Source index within the manifest.
+
+    Returns:
+        Path for the normalized source raster or VRT.
+    """
+
+    suffix = ".vrt" if policy.source_nodata == policy.output_nodata else ".tif"
+    return output_dir / f"{index:05d}_{source_path.stem}{suffix}"
+
+
+def normalize_source_nodata(
+    source_path: Path,
+    output_path: Path,
+    policy: NodataPolicy,
+    gdal_translate_exe: str,
+    gdal_warp_exe: str,
+) -> None:
+    """Create a source raster view/copy with corrected nodata semantics.
+
+    When source and output nodata are the same, a lightweight VRT with corrected
+    nodata metadata is enough. When values differ, a temporary GeoTIFF is
+    written so source nodata pixels become the desired output nodata value.
+
+    Args:
+        source_path: Original source raster path.
+        output_path: Normalized source path to create.
+        policy: Nodata policy to apply.
+        gdal_translate_exe: gdal_translate executable.
+        gdal_warp_exe: gdalwarp executable.
+
+    Raises:
+        subprocess.CalledProcessError: If GDAL normalization fails.
+    """
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.exists():
+        output_path.unlink()
+
+    if policy.source_nodata == policy.output_nodata:
+        command = [
+            gdal_translate_exe,
+            str(source_path),
+            str(output_path),
+            "-of",
+            "VRT",
+            "-a_nodata",
+            policy.output_nodata,
+        ]
+    else:
+        command = [
+            gdal_warp_exe,
+            "-overwrite",
+            "-srcnodata",
+            policy.source_nodata,
+            "-dstnodata",
+            policy.output_nodata,
+            "-of",
+            "GTiff",
+            "-co",
+            "TILED=YES",
+            "-co",
+            "COMPRESS=DEFLATE",
+            "-co",
+            "PREDICTOR=YES",
+            str(source_path),
+            str(output_path),
+        ]
+    subprocess.run(command, check=True)
+
+
+def prepare_manifest_for_nodata_policy(
+    manifest_path: Path,
+    policy: NodataPolicy,
+    prepared_manifest_path: Path,
+    normalized_source_dir: Path,
+    gdal_translate_exe: str,
+    gdal_warp_exe: str,
+) -> Path:
+    """Create a temporary manifest with normalized source rasters.
+
+    Args:
+        manifest_path: Original stitch manifest path.
+        policy: Nodata policy to apply.
+        prepared_manifest_path: Temporary manifest path to write.
+        normalized_source_dir: Directory for normalized source rasters.
+        gdal_translate_exe: gdal_translate executable.
+        gdal_warp_exe: gdalwarp executable.
+
+    Returns:
+        Temporary manifest path.
+    """
+
+    source_paths = read_manifest_sources(manifest_path)
+    normalized_paths = []
+    total = len(source_paths)
+    print(
+        f"Preparing nodata policy for {manifest_path.stem}: "
+        f"{policy.source_nodata} -> {policy.output_nodata} ({total} source rasters)"
+    )
+    for index, source_path in enumerate(source_paths, start=1):
+        normalized_path = normalized_source_path(
+            source_path=source_path,
+            policy=policy,
+            output_dir=normalized_source_dir,
+            index=index,
+        )
+        print(f"  {index}/{total} {source_path.name}")
+        normalize_source_nodata(
+            source_path=source_path,
+            output_path=normalized_path,
+            policy=policy,
+            gdal_translate_exe=gdal_translate_exe,
+            gdal_warp_exe=gdal_warp_exe,
+        )
+        normalized_paths.append(normalized_path)
+    write_manifest(prepared_manifest_path, normalized_paths)
+    return prepared_manifest_path
+
+
+def prepare_manifests_for_stitching(
+    manifest_paths: Sequence[Path],
+    policies: dict[str, NodataPolicy],
+    work_dir: Path,
+    gdal_translate_exe: str,
+    gdal_warp_exe: str,
+    dry_run: bool,
+) -> tuple[list[Path], Path | None]:
+    """Prepare temporary manifests for nodata-aware stitching.
+
+    Args:
+        manifest_paths: Original stitch manifests.
+        policies: Per-manifest nodata policies.
+        work_dir: Temporary working directory.
+        gdal_translate_exe: gdal_translate executable.
+        gdal_warp_exe: gdalwarp executable.
+        dry_run: Whether to describe work without creating files.
+
+    Returns:
+        Prepared manifest paths and the directory containing them. If no
+        policies are defined, the original manifests and None are returned.
+    """
+
+    if not policies:
+        return list(manifest_paths), None
+
+    prepared_manifest_dir = work_dir / "manifests"
+    normalized_source_root = work_dir / "nodata_sources"
+    prepared_paths = []
+    for manifest_path in manifest_paths:
+        prepared_manifest_path = prepared_manifest_dir / manifest_path.name
+        policy = policies.get(manifest_path.stem)
+        if dry_run:
+            if policy is None:
+                print(f"Would copy manifest unchanged: {manifest_path.name}")
+            else:
+                print(
+                    f"Would normalize {manifest_path.name}: "
+                    f"{policy.source_nodata} -> {policy.output_nodata}"
+                )
+            prepared_paths.append(prepared_manifest_path)
+            continue
+
+        if policy is None:
+            write_manifest(prepared_manifest_path, read_manifest_sources(manifest_path))
+        else:
+            prepare_manifest_for_nodata_policy(
+                manifest_path=manifest_path,
+                policy=policy,
+                prepared_manifest_path=prepared_manifest_path,
+                normalized_source_dir=normalized_source_root / manifest_path.stem,
+                gdal_translate_exe=gdal_translate_exe,
+                gdal_warp_exe=gdal_warp_exe,
+            )
+        prepared_paths.append(prepared_manifest_path)
+    return prepared_paths, prepared_manifest_dir
 
 
 def make_jobs(
@@ -648,12 +938,34 @@ def main() -> None:
 
     args = parse_args()
     manifest_dir = args.manifest_dir.resolve()
-    stitched_dir = (args.stitched_dir or args.manifest_dir).resolve()
     publish_dir = args.publish_dir.resolve()
+    work_dir = (args.work_dir or (args.manifest_dir / "_build_country_cogs")).resolve()
+    policies = parse_nodata_policies(args.nodata_policy)
 
     manifest_paths = discover_manifests(manifest_dir, args.manifest_glob)
+    prepared_manifest_paths = manifest_paths
+    prepared_manifest_dir = None
+    if policies and not args.skip_stitch:
+        if not args.dry_run:
+            check_executable(args.gdal_translate)
+            check_executable(args.gdal_warp)
+        prepared_manifest_paths, prepared_manifest_dir = prepare_manifests_for_stitching(
+            manifest_paths=manifest_paths,
+            policies=policies,
+            work_dir=work_dir,
+            gdal_translate_exe=args.gdal_translate,
+            gdal_warp_exe=args.gdal_warp,
+            dry_run=args.dry_run,
+        )
+
+    stitch_manifest_dir = prepared_manifest_dir or manifest_dir
+    stitched_dir = (
+        args.stitched_dir.resolve()
+        if args.stitched_dir
+        else (prepared_manifest_dir or manifest_dir).resolve()
+    )
     jobs = make_jobs(
-        manifest_paths=manifest_paths,
+        manifest_paths=prepared_manifest_paths,
         stitched_dir=stitched_dir,
         publish_dir=publish_dir,
         output_suffix=args.output_suffix,
@@ -667,9 +979,9 @@ def main() -> None:
     if not args.skip_stitch:
         run_stitcher(
             stitch_script=args.stitch_script.resolve(),
-            manifest_dir=manifest_dir,
+            manifest_dir=stitch_manifest_dir,
             manifest_glob=args.manifest_glob,
-            manifest_paths=manifest_paths,
+            manifest_paths=prepared_manifest_paths,
             stitch_input_mode=args.stitch_input_mode,
             workers=args.workers,
             output_suffix=args.output_suffix,

--- a/utils/build_country_cogs.py
+++ b/utils/build_country_cogs.py
@@ -287,11 +287,35 @@ def read_manifest_sources(manifest_path: Path) -> list[Path]:
         Source raster paths listed in the manifest.
     """
 
+    manifest_text = read_manifest_text(manifest_path)
     return [
         Path(line.strip())
-        for line in manifest_path.read_text(encoding="utf-8").splitlines()
+        for line in manifest_text.splitlines()
         if line.strip()
     ]
+
+
+def read_manifest_text(manifest_path: Path) -> str:
+    """Read a stitch manifest using common text encodings.
+
+    Args:
+        manifest_path: Text file with one source raster path per line.
+
+    Returns:
+        Decoded manifest text.
+
+    Raises:
+        UnicodeDecodeError: If the manifest cannot be decoded with supported
+            encodings.
+    """
+
+    manifest_bytes = manifest_path.read_bytes()
+    for encoding in ("utf-8-sig", "utf-16", "utf-16-le", "utf-16-be"):
+        try:
+            return manifest_bytes.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    return manifest_bytes.decode("utf-8")
 
 
 def write_manifest(manifest_path: Path, source_paths: Sequence[Path]) -> None:

--- a/utils/build_country_cogs.py
+++ b/utils/build_country_cogs.py
@@ -53,13 +53,14 @@ class NodataPolicy:
 
     Attributes:
         raster_name: Manifest stem the policy applies to.
-        source_nodata: Value that should be treated as nodata before stitching.
+        source_nodata_values: Values that should be treated as nodata before
+            stitching.
         output_nodata: Value that should be written as nodata for stitching and
             COG publication.
     """
 
     raster_name: str
-    source_nodata: str
+    source_nodata_values: tuple[str, ...]
     output_nodata: str
 
 
@@ -171,9 +172,10 @@ def parse_args() -> argparse.Namespace:
         metavar="NAME:SOURCE:OUTPUT",
         help=(
             "Per-raster nodata normalization applied before stitching. NAME "
-            "is the manifest stem without .txt, SOURCE is the value to treat "
-            "as nodata in source rasters, and OUTPUT is the nodata value to "
-            "write for stitching and COGs. Repeat for multiple rasters."
+            "is the manifest stem without .txt, SOURCE is one value or a "
+            "comma-separated list of values to treat as nodata in source "
+            "rasters, and OUTPUT is the nodata value to write for stitching "
+            "and COGs. Repeat for multiple rasters."
         ),
     )
     parser.add_argument(
@@ -251,7 +253,7 @@ def parse_nodata_policies(policy_values: Sequence[str]) -> dict[str, NodataPolic
     """Parse per-raster nodata policy CLI values.
 
     Args:
-        policy_values: Values formatted as NAME:SOURCE:OUTPUT.
+        policy_values: Values formatted as NAME:SOURCE[,SOURCE...]:OUTPUT.
 
     Returns:
         Mapping of manifest stem to nodata policy.
@@ -269,12 +271,51 @@ def parse_nodata_policies(policy_values: Sequence[str]) -> dict[str, NodataPolic
                 f"Got: {policy_value}"
             )
         raster_name, source_nodata, output_nodata = parts
+        source_nodata_values = tuple(
+            value.strip() for value in source_nodata.split(",") if value.strip()
+        )
+        if not source_nodata_values:
+            raise ValueError(f"Nodata policy has no source nodata values: {policy_value}")
         policies[raster_name] = NodataPolicy(
             raster_name=raster_name,
-            source_nodata=source_nodata,
+            source_nodata_values=source_nodata_values,
             output_nodata=output_nodata,
         )
     return policies
+
+
+def format_source_nodata_values(policy: NodataPolicy) -> str:
+    """Format source nodata values for logs.
+
+    Args:
+        policy: Nodata policy to format.
+
+    Returns:
+        Comma-separated source nodata values.
+    """
+
+    return ",".join(policy.source_nodata_values)
+
+
+def parse_nodata_value(value: str):
+    """Parse a nodata value as an int where possible, otherwise float.
+
+    Args:
+        value: Nodata value from the command line.
+
+    Returns:
+        Numeric nodata value.
+    """
+
+    lowered_value = value.lower()
+    if any(char in lowered_value for char in ".e") or lowered_value in {
+        "nan",
+        "inf",
+        "+inf",
+        "-inf",
+    }:
+        return float(value)
+    return int(value)
 
 
 def read_manifest_sources(manifest_path: Path) -> list[Path]:
@@ -348,8 +389,7 @@ def normalized_source_path(
         Path for the normalized source raster or VRT.
     """
 
-    suffix = ".vrt" if policy.source_nodata == policy.output_nodata else ".tif"
-    return output_dir / f"{index:05d}_{source_path.stem}{suffix}"
+    return output_dir / f"{index:05d}_{source_path.stem}.tif"
 
 
 def normalize_source_nodata(
@@ -361,9 +401,9 @@ def normalize_source_nodata(
 ) -> None:
     """Create a source raster view/copy with corrected nodata semantics.
 
-    When source and output nodata are the same, a lightweight VRT with corrected
-    nodata metadata is enough. When values differ, a temporary GeoTIFF is
-    written so source nodata pixels become the desired output nodata value.
+    Every listed source nodata value is rewritten to the output nodata value so
+    the stitcher sees one consistent nodata value regardless of source raster
+    metadata.
 
     Args:
         source_path: Original source raster path.
@@ -373,41 +413,58 @@ def normalize_source_nodata(
         gdal_warp_exe: gdalwarp executable.
 
     Raises:
-        subprocess.CalledProcessError: If GDAL normalization fails.
+        ImportError: If rasterio is not available in the current Python
+            environment.
     """
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     if output_path.exists():
         output_path.unlink()
 
-    if policy.source_nodata == policy.output_nodata:
-        command = [
-            gdal_translate_exe,
-            str(source_path),
-            str(output_path),
-            "-of",
-            "VRT",
-            "-a_nodata",
-            policy.output_nodata,
-        ]
-    else:
-        command = [
-            gdal_warp_exe,
-            "-overwrite",
-            "-srcnodata",
-            policy.source_nodata,
-            "-dstnodata",
-            policy.output_nodata,
-            "-of",
-            "GTiff",
-            "-co",
-            "TILED=YES",
-            "-co",
-            "COMPRESS=DEFLATE",
-            str(source_path),
-            str(output_path),
-        ]
-    subprocess.run(command, check=True)
+    normalize_source_nodata_with_rasterio(source_path, output_path, policy)
+
+
+def normalize_source_nodata_with_rasterio(
+    source_path: Path, output_path: Path, policy: NodataPolicy
+) -> None:
+    """Normalize source nodata values with block-wise rasterio IO.
+
+    Args:
+        source_path: Original source raster path.
+        output_path: Normalized raster path to create.
+        policy: Nodata policy to apply.
+    """
+
+    import numpy
+    import rasterio
+
+    output_nodata = parse_nodata_value(policy.output_nodata)
+    source_nodata_values = [
+        parse_nodata_value(value) for value in policy.source_nodata_values
+    ]
+
+    with rasterio.open(source_path) as source:
+        profile = source.profile.copy()
+        profile.update(
+            driver="GTiff",
+            nodata=output_nodata,
+            tiled=True,
+            compress="DEFLATE",
+        )
+        with rasterio.open(output_path, "w", **profile) as target:
+            for _, window in source.block_windows(1):
+                data = source.read(window=window)
+                nodata_mask = numpy.zeros(data.shape, dtype=bool)
+                for source_nodata in source_nodata_values:
+                    if (
+                        numpy.issubdtype(data.dtype, numpy.floating)
+                        and numpy.isnan(source_nodata)
+                    ):
+                        nodata_mask |= numpy.isnan(data)
+                    else:
+                        nodata_mask |= data == source_nodata
+                data[nodata_mask] = output_nodata
+                target.write(data, window=window)
 
 
 def prepare_manifest_for_nodata_policy(
@@ -437,7 +494,8 @@ def prepare_manifest_for_nodata_policy(
     total = len(source_paths)
     print(
         f"Preparing nodata policy for {manifest_path.stem}: "
-        f"{policy.source_nodata} -> {policy.output_nodata} ({total} source rasters)"
+        f"{format_source_nodata_values(policy)} -> {policy.output_nodata} "
+        f"({total} source rasters)"
     )
     for index, source_path in enumerate(source_paths, start=1):
         normalized_path = normalized_source_path(
@@ -497,7 +555,7 @@ def prepare_manifests_for_stitching(
             else:
                 print(
                     f"Would normalize {manifest_path.name}: "
-                    f"{policy.source_nodata} -> {policy.output_nodata}"
+                    f"{format_source_nodata_values(policy)} -> {policy.output_nodata}"
                 )
             prepared_paths.append(prepared_manifest_path)
             continue

--- a/utils/build_country_cogs.py
+++ b/utils/build_country_cogs.py
@@ -1,0 +1,624 @@
+"""Build stitched country rasters and publish COGs for GeoServer.
+
+This utility wraps the local raster preparation workflow:
+
+1. Discover raster stitch manifest text files.
+2. Run the existing parallel stitcher once.
+3. Inspect each stitched raster dtype.
+4. Convert each stitched raster to a Cloud Optimized GeoTIFF using average
+   overview resampling for floating-point rasters and mode resampling for
+   integer/categorical rasters.
+5. Write the finished COGs directly to a GeoServer-ready publish directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from typing import Iterator, Sequence
+
+
+FLOAT_GDAL_TYPES = {"Float16", "Float32", "Float64", "CFloat32", "CFloat64"}
+
+
+@dataclass(frozen=True)
+class RasterJob:
+    """Describes a stitched raster and the COG that should be created.
+
+    Attributes:
+        manifest_path: Path to the text manifest used by the stitcher.
+        stitched_path: Expected stitched raster path.
+        output_path: Final COG path in the publish directory.
+        dtype: GDAL raster data type, populated after inspection.
+        resampling: GDAL overview resampling method, populated after inspection.
+    """
+
+    manifest_path: Path
+    stitched_path: Path
+    output_path: Path
+    dtype: str | None = None
+    resampling: str | None = None
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        Parsed arguments for the pipeline.
+    """
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Stitch country raster manifests, convert stitched rasters to COGs, "
+            "and publish them to a GeoServer-ready directory."
+        )
+    )
+    parser.add_argument(
+        "--manifest-dir",
+        type=Path,
+        required=True,
+        help="Directory containing the stitcher .txt manifest files.",
+    )
+    parser.add_argument(
+        "--publish-dir",
+        type=Path,
+        required=True,
+        help="Directory where final COGs should be written for GeoServer.",
+    )
+    parser.add_argument(
+        "--stitched-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Directory where stitched rasters are expected. Defaults to "
+            "--manifest-dir."
+        ),
+    )
+    parser.add_argument(
+        "--manifest-glob",
+        default="*.txt",
+        help="Glob used to discover manifest files inside --manifest-dir.",
+    )
+    parser.add_argument(
+        "--stitch-script",
+        type=Path,
+        default=Path(__file__).with_name("run_parallel_stitch_rasters.py"),
+        help=(
+            "Path to run_parallel_stitch_rasters.py. Defaults to the same "
+            "directory as this script."
+        ),
+    )
+    parser.add_argument(
+        "--stitch-input-mode",
+        choices=("glob", "files"),
+        default="glob",
+        help=(
+            "Pass one glob pattern to the stitcher, matching the existing ad "
+            "hoc command, or pass every discovered manifest as a separate "
+            "argument."
+        ),
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=12,
+        help="Worker count passed to the stitcher.",
+    )
+    parser.add_argument(
+        "--output-suffix",
+        default="_stitched",
+        help="Suffix used by the stitcher for output rasters.",
+    )
+    parser.add_argument(
+        "--nodata",
+        default="0",
+        help=(
+            "Nodata value passed to the stitcher and assigned to output COGs. "
+            "Use an empty string to skip -a_nodata during COG creation."
+        ),
+    )
+    parser.add_argument(
+        "--gdal-translate",
+        default="gdal_translate",
+        help="gdal_translate executable to use.",
+    )
+    parser.add_argument(
+        "--gdalinfo",
+        default="gdalinfo",
+        help="gdalinfo executable to use for dtype inspection.",
+    )
+    parser.add_argument(
+        "--resampling-option",
+        default="RESAMPLING",
+        help=(
+            "COG creation option name for overview resampling. GDAL's COG "
+            "driver commonly uses RESAMPLING; use OVERVIEW_RESAMPLING if your "
+            "installed GDAL build expects that option."
+        ),
+    )
+    parser.add_argument(
+        "--compression",
+        default="DEFLATE",
+        help="COG compression creation option.",
+    )
+    parser.add_argument(
+        "--blocksize",
+        default="512",
+        help="COG block size creation option.",
+    )
+    parser.add_argument(
+        "--gdal-threads",
+        default="1",
+        help="NUM_THREADS creation option passed to gdal_translate.",
+    )
+    parser.add_argument(
+        "--skip-stitch",
+        action="store_true",
+        help="Skip the stitch step and only COG existing stitched rasters.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned work without running stitch or COG commands.",
+    )
+    return parser.parse_args()
+
+
+def discover_manifests(manifest_dir: Path, manifest_glob: str) -> list[Path]:
+    """Find stitch manifest files.
+
+    Args:
+        manifest_dir: Directory containing manifest text files.
+        manifest_glob: Glob pattern used to select manifest files.
+
+    Returns:
+        Sorted list of manifest paths.
+
+    Raises:
+        FileNotFoundError: If the manifest directory does not exist.
+        RuntimeError: If no manifest files match the glob.
+    """
+
+    if not manifest_dir.is_dir():
+        raise FileNotFoundError(f"Manifest directory does not exist: {manifest_dir}")
+
+    manifest_paths = sorted(manifest_dir.glob(manifest_glob))
+    if not manifest_paths:
+        raise RuntimeError(f"No manifests matched {manifest_glob!r} in {manifest_dir}")
+    return manifest_paths
+
+
+def make_jobs(
+    manifest_paths: Sequence[Path],
+    stitched_dir: Path,
+    publish_dir: Path,
+    output_suffix: str,
+) -> list[RasterJob]:
+    """Create planned raster conversion jobs from manifest paths.
+
+    Args:
+        manifest_paths: Stitch manifest paths.
+        stitched_dir: Directory where stitched rasters are expected.
+        publish_dir: Directory for final COG outputs.
+        output_suffix: Suffix used for stitched raster names.
+
+    Returns:
+        Planned raster jobs.
+    """
+
+    jobs = []
+    for manifest_path in manifest_paths:
+        stitched_name = f"{manifest_path.stem}{output_suffix}.tif"
+        jobs.append(
+            RasterJob(
+                manifest_path=manifest_path,
+                stitched_path=stitched_dir / stitched_name,
+                output_path=publish_dir / stitched_name,
+            )
+        )
+    return jobs
+
+
+def format_command(command: Sequence[str]) -> str:
+    """Format a command for readable logs.
+
+    Args:
+        command: Command arguments.
+
+    Returns:
+        A command string suitable for console output.
+    """
+
+    if os.name == "nt":
+        return subprocess.list2cmdline([str(part) for part in command])
+    return " ".join(shlex_quote(str(part)) for part in command)
+
+
+def shlex_quote(value: str) -> str:
+    """Quote a shell argument for POSIX-style display.
+
+    Args:
+        value: Raw shell argument.
+
+    Returns:
+        Quoted argument.
+    """
+
+    import shlex
+
+    return shlex.quote(value)
+
+
+def run_stitcher(
+    stitch_script: Path,
+    manifest_dir: Path,
+    manifest_glob: str,
+    manifest_paths: Sequence[Path],
+    stitch_input_mode: str,
+    workers: int,
+    output_suffix: str,
+    nodata: str,
+    dry_run: bool,
+) -> None:
+    """Run the existing parallel stitcher script.
+
+    Args:
+        stitch_script: Path to the stitcher script.
+        manifest_dir: Directory containing manifests.
+        manifest_glob: Glob used when stitch_input_mode is "glob".
+        manifest_paths: Discovered manifest paths.
+        stitch_input_mode: Whether to pass one glob or individual files.
+        workers: Worker count passed to the stitcher.
+        output_suffix: Output suffix passed to the stitcher.
+        nodata: Nodata value passed to the stitcher.
+        dry_run: Whether to print without executing.
+
+    Raises:
+        FileNotFoundError: If the stitcher script is missing.
+        subprocess.CalledProcessError: If the stitcher fails.
+    """
+
+    if not dry_run and not stitch_script.is_file():
+        raise FileNotFoundError(
+            f"Stitch script does not exist: {stitch_script}. "
+            "Pass --stitch-script if it lives elsewhere."
+        )
+
+    command = [sys.executable, str(stitch_script)]
+    if stitch_input_mode == "glob":
+        command.append(str(manifest_dir / manifest_glob))
+    else:
+        command.extend(str(path) for path in manifest_paths)
+    command.extend(["--workers", str(workers), "--output-suffix", output_suffix])
+    if nodata != "":
+        command.extend(["--nodata", nodata])
+
+    print(f"Stitch command: {format_command(command)}")
+    if dry_run:
+        return
+    subprocess.run(command, check=True)
+
+
+def inspect_gdal_dtype(gdalinfo_exe: str, raster_path: Path) -> str:
+    """Inspect a raster's first-band dtype with gdalinfo.
+
+    Args:
+        gdalinfo_exe: gdalinfo executable.
+        raster_path: Raster path to inspect.
+
+    Returns:
+        GDAL type string for the first band.
+
+    Raises:
+        RuntimeError: If gdalinfo output does not include band type metadata.
+        subprocess.CalledProcessError: If gdalinfo fails.
+    """
+
+    result = subprocess.run(
+        [gdalinfo_exe, "-json", str(raster_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    metadata = json.loads(result.stdout)
+    bands = metadata.get("bands", [])
+    if not bands or "type" not in bands[0]:
+        raise RuntimeError(f"Could not determine raster dtype from {raster_path}")
+    return str(bands[0]["type"])
+
+
+def resampling_for_dtype(dtype: str) -> str:
+    """Choose overview resampling for a GDAL dtype.
+
+    Args:
+        dtype: GDAL raster type string.
+
+    Returns:
+        "AVERAGE" for floating-point rasters and "MODE" otherwise.
+    """
+
+    if dtype in FLOAT_GDAL_TYPES:
+        return "AVERAGE"
+    return "MODE"
+
+
+def progress_iter(items: Sequence[RasterJob], label: str) -> Iterator[RasterJob]:
+    """Yield jobs with tqdm-style progress output.
+
+    Args:
+        items: Jobs to iterate over.
+        label: Progress label.
+
+    Yields:
+        Raster jobs.
+    """
+
+    try:
+        from tqdm import tqdm
+    except ImportError:
+        total = len(items)
+        for index, item in enumerate(items, start=1):
+            print(f"{label}: {index}/{total} {item.stitched_path.name}")
+            yield item
+    else:
+        yield from tqdm(items, desc=label, unit="raster")
+
+
+def inspect_jobs(gdalinfo_exe: str, jobs: Sequence[RasterJob]) -> list[RasterJob]:
+    """Populate dtype and resampling for planned jobs.
+
+    Args:
+        gdalinfo_exe: gdalinfo executable.
+        jobs: Planned raster jobs.
+
+    Returns:
+        Jobs with dtype and resampling populated.
+    """
+
+    inspected_jobs = []
+    for job in progress_iter(list(jobs), "Inspecting rasters"):
+        dtype = inspect_gdal_dtype(gdalinfo_exe, job.stitched_path)
+        inspected_jobs.append(
+            RasterJob(
+                manifest_path=job.manifest_path,
+                stitched_path=job.stitched_path,
+                output_path=job.output_path,
+                dtype=dtype,
+                resampling=resampling_for_dtype(dtype),
+            )
+        )
+    return inspected_jobs
+
+
+def ensure_stitched_outputs(jobs: Sequence[RasterJob]) -> None:
+    """Check that every expected stitched raster exists.
+
+    Args:
+        jobs: Planned raster jobs.
+
+    Raises:
+        FileNotFoundError: If any stitched raster is missing.
+    """
+
+    missing_paths = [job.stitched_path for job in jobs if not job.stitched_path.is_file()]
+    if missing_paths:
+        missing_lines = "\n".join(f"  - {path}" for path in missing_paths)
+        raise FileNotFoundError(
+            "Expected stitched raster outputs were not found:\n" f"{missing_lines}"
+        )
+
+
+def convert_to_cog(
+    gdal_translate_exe: str,
+    job: RasterJob,
+    nodata: str,
+    resampling_option: str,
+    compression: str,
+    blocksize: str,
+    gdal_threads: str,
+    dry_run: bool,
+) -> None:
+    """Convert one stitched raster to a COG in the publish directory.
+
+    Args:
+        gdal_translate_exe: gdal_translate executable.
+        job: Raster conversion job with dtype/resampling populated.
+        nodata: Nodata value assigned with -a_nodata, or empty string to skip.
+        resampling_option: COG creation option name for overview resampling.
+        compression: Compression creation option value.
+        blocksize: Block size creation option value.
+        gdal_threads: NUM_THREADS creation option value.
+        dry_run: Whether to print without executing.
+
+    Raises:
+        subprocess.CalledProcessError: If gdal_translate fails.
+    """
+
+    temp_output_path = job.output_path.with_name(
+        f"{job.output_path.stem}.tmp{job.output_path.suffix}"
+    )
+    command = [
+        gdal_translate_exe,
+        str(job.stitched_path),
+        str(temp_output_path),
+        "-of",
+        "COG",
+        "-co",
+        f"COMPRESS={compression}",
+        "-co",
+        "PREDICTOR=YES",
+        "-co",
+        f"BLOCKSIZE={blocksize}",
+        "-co",
+        f"{resampling_option}={job.resampling}",
+        "-co",
+        f"NUM_THREADS={gdal_threads}",
+    ]
+    if nodata != "":
+        command.extend(["-a_nodata", nodata])
+
+    if dry_run:
+        print(f"COG command: {format_command(command)}")
+        return
+
+    job.output_path.parent.mkdir(parents=True, exist_ok=True)
+    if temp_output_path.exists():
+        temp_output_path.unlink()
+    subprocess.run(command, check=True)
+    os.replace(temp_output_path, job.output_path)
+
+
+def convert_jobs_to_cogs(
+    gdal_translate_exe: str,
+    jobs: Sequence[RasterJob],
+    nodata: str,
+    resampling_option: str,
+    compression: str,
+    blocksize: str,
+    gdal_threads: str,
+    dry_run: bool,
+) -> None:
+    """Convert all planned jobs to COGs.
+
+    Args:
+        gdal_translate_exe: gdal_translate executable.
+        jobs: Raster jobs to convert.
+        nodata: Nodata value assigned with -a_nodata, or empty string to skip.
+        resampling_option: COG creation option name for overview resampling.
+        compression: Compression creation option value.
+        blocksize: Block size creation option value.
+        gdal_threads: NUM_THREADS creation option value.
+        dry_run: Whether to print without executing.
+    """
+
+    for job in progress_iter(list(jobs), "Converting COGs"):
+        convert_to_cog(
+            gdal_translate_exe=gdal_translate_exe,
+            job=job,
+            nodata=nodata,
+            resampling_option=resampling_option,
+            compression=compression,
+            blocksize=blocksize,
+            gdal_threads=gdal_threads,
+            dry_run=dry_run,
+        )
+
+
+def check_executable(name: str) -> None:
+    """Check that an executable can be found on PATH.
+
+    Args:
+        name: Executable name or path.
+
+    Raises:
+        FileNotFoundError: If the executable is not available.
+    """
+
+    if Path(name).is_file():
+        return
+    if shutil.which(name) is None:
+        raise FileNotFoundError(f"Required executable not found: {name}")
+
+
+def print_summary(jobs: Sequence[RasterJob]) -> None:
+    """Print a final summary table.
+
+    Args:
+        jobs: Completed or planned raster jobs.
+    """
+
+    rows = [
+        (
+            job.stitched_path.name,
+            job.dtype or "unknown",
+            job.resampling or "unknown",
+            str(job.output_path),
+        )
+        for job in jobs
+    ]
+    widths = [
+        max(len("raster"), *(len(row[0]) for row in rows)),
+        max(len("dtype"), *(len(row[1]) for row in rows)),
+        max(len("resampling"), *(len(row[2]) for row in rows)),
+    ]
+    print("\nSummary")
+    print(
+        f"{'raster':<{widths[0]}}  "
+        f"{'dtype':<{widths[1]}}  "
+        f"{'resampling':<{widths[2]}}  output"
+    )
+    print(
+        f"{'-' * widths[0]}  "
+        f"{'-' * widths[1]}  "
+        f"{'-' * widths[2]}  {'-' * 6}"
+    )
+    for raster_name, dtype, resampling, output_path in rows:
+        print(
+            f"{raster_name:<{widths[0]}}  "
+            f"{dtype:<{widths[1]}}  "
+            f"{resampling:<{widths[2]}}  {output_path}"
+        )
+
+
+def main() -> None:
+    """Run the stitch-to-COG pipeline."""
+
+    args = parse_args()
+    manifest_dir = args.manifest_dir.resolve()
+    stitched_dir = (args.stitched_dir or args.manifest_dir).resolve()
+    publish_dir = args.publish_dir.resolve()
+
+    manifest_paths = discover_manifests(manifest_dir, args.manifest_glob)
+    jobs = make_jobs(
+        manifest_paths=manifest_paths,
+        stitched_dir=stitched_dir,
+        publish_dir=publish_dir,
+        output_suffix=args.output_suffix,
+    )
+
+    print(f"Found {len(manifest_paths)} manifest(s) in {manifest_dir}")
+    print(f"Expected stitched rasters in {stitched_dir}")
+    print(f"Publishing COGs to {publish_dir}")
+
+    if not args.skip_stitch:
+        run_stitcher(
+            stitch_script=args.stitch_script.resolve(),
+            manifest_dir=manifest_dir,
+            manifest_glob=args.manifest_glob,
+            manifest_paths=manifest_paths,
+            stitch_input_mode=args.stitch_input_mode,
+            workers=args.workers,
+            output_suffix=args.output_suffix,
+            nodata=args.nodata,
+            dry_run=args.dry_run,
+        )
+
+    if args.dry_run:
+        print_summary(jobs)
+        return
+
+    check_executable(args.gdalinfo)
+    check_executable(args.gdal_translate)
+    ensure_stitched_outputs(jobs)
+    inspected_jobs = inspect_jobs(args.gdalinfo, jobs)
+    convert_jobs_to_cogs(
+        gdal_translate_exe=args.gdal_translate,
+        jobs=inspected_jobs,
+        nodata=args.nodata,
+        resampling_option=args.resampling_option,
+        compression=args.compression,
+        blocksize=args.blocksize,
+        gdal_threads=args.gdal_threads,
+        dry_run=args.dry_run,
+    )
+    print_summary(inspected_jobs)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/build_country_cogs.py
+++ b/utils/build_country_cogs.py
@@ -404,8 +404,6 @@ def normalize_source_nodata(
             "TILED=YES",
             "-co",
             "COMPRESS=DEFLATE",
-            "-co",
-            "PREDICTOR=YES",
             str(source_path),
             str(output_path),
         ]

--- a/utils/build_country_cogs.py
+++ b/utils/build_country_cogs.py
@@ -583,6 +583,7 @@ def run_stitcher(
     manifest_dir: Path,
     manifest_glob: str,
     manifest_paths: Sequence[Path],
+    output_dir: Path,
     stitch_input_mode: str,
     workers: int,
     output_suffix: str,
@@ -596,6 +597,7 @@ def run_stitcher(
         manifest_dir: Directory containing manifests.
         manifest_glob: Glob used when stitch_input_mode is "glob".
         manifest_paths: Discovered manifest paths.
+        output_dir: Directory where stitched rasters should be written.
         stitch_input_mode: Whether to pass one glob or individual files.
         workers: Worker count passed to the stitcher.
         output_suffix: Output suffix passed to the stitcher.
@@ -619,6 +621,7 @@ def run_stitcher(
     else:
         command.extend(str(path) for path in manifest_paths)
     command.extend(["--workers", str(workers), "--output-suffix", output_suffix])
+    command.extend(["--output-dir", str(output_dir)])
     if nodata != "":
         command.extend(["--nodata", nodata])
 
@@ -980,12 +983,12 @@ def main() -> None:
             dry_run=args.dry_run,
         )
 
-    stitch_manifest_dir = prepared_manifest_dir or manifest_dir
     stitched_dir = (
         args.stitched_dir.resolve()
         if args.stitched_dir
-        else (prepared_manifest_dir or manifest_dir).resolve()
+        else manifest_dir.resolve()
     )
+    stitch_manifest_dir = prepared_manifest_dir or manifest_dir
     jobs = make_jobs(
         manifest_paths=prepared_manifest_paths,
         stitched_dir=stitched_dir,
@@ -1004,6 +1007,7 @@ def main() -> None:
             manifest_dir=stitch_manifest_dir,
             manifest_glob=args.manifest_glob,
             manifest_paths=prepared_manifest_paths,
+            output_dir=stitched_dir,
             stitch_input_mode=args.stitch_input_mode,
             workers=args.workers,
             output_suffix=args.output_suffix,


### PR DESCRIPTION
## Summary

- Adds `utils/build_country_cogs.py`, a CLI utility for discovering stitch manifests, running the existing stitcher, inspecting stitched raster dtypes, and publishing COGs directly to a GeoServer-ready directory.
- Selects COG overview resampling from dtype: floating-point rasters use `AVERAGE`, integer/categorical rasters use `MODE`.
- Adds dry-run support, configurable stitch/GDAL options, tqdm-style progress with a no-dependency fallback, temporary COG outputs, and a final summary table.
- Adds `--cog-workers` so COG generation can run multiple `gdal_translate` jobs in parallel while keeping per-process `--gdal-threads` configurable.
- Adds repeatable `--nodata-policy NAME:SOURCE:OUTPUT` support so problematic rasters can be normalized before stitching; `SOURCE` may be a comma-separated list such as `0,-9999`.
- Supports UTF-8/UTF-16 stitch manifests so Windows-created manifest files can be read without manual conversion.
- Ensures corrected stitches are written to the configured stitched/output directory even when temporary nodata-aware manifests are used.
- Preserves stitched raster nodata metadata during COG publication instead of overriding COG nodata independently of pixel values.
- Updates `history.rst`.

## Notes

The repository does not currently include `run_parallel_stitch_rasters.py`, so the utility defaults to looking beside itself but also supports `--stitch-script` for the local path where that existing stitcher lives.

For large rasters, start with `--cog-workers 2` or `--cog-workers 3` and keep `--gdal-threads 1`. Raising both at once can oversubscribe CPU, RAM, and disk I/O.

The nodata policy format is `manifest_stem:source_nodata[,source_nodata...]:output_nodata`. For the current known raster issues:

```powershell
--nodata-policy restoration_carbon:0,-9999:0 `
--nodata-policy restoration_biodiversity:-9999:0 `
--nodata-policy sustainable_current_biodiversity:-9999:0 `
--nodata-policy sustainable_current_carbon:-9999,0:0
```

The policy normalizes each listed source nodata value to the output nodata value before stitching, so a raster can override incorrect source metadata and treat multiple bad values as invalid.

## Validation

- `python -B -m py_compile utils/build_country_cogs.py`
- `python -B utils/build_country_cogs.py --help`
- `python -B utils/build_country_cogs.py --manifest-dir D:/frontiers_data/countries --publish-dir D:/frontiers_data/countries/cog --workers 12 --cog-workers 3 --nodata 0 --dry-run`
- `python -B utils/build_country_cogs.py --manifest-dir D:/frontiers_data/countries --publish-dir D:/frontiers_data/countries/cog --stitch-script D:/repositories/wwf_es_beneficiaries/utils/run_parallel_stitch_rasters.py --workers 12 --cog-workers 3 --gdal-threads 1 --nodata 0 --nodata-policy restoration_carbon:0,-9999:0 --nodata-policy restoration_biodiversity:-9999:0 --nodata-policy sustainable_current_biodiversity:-9999:0 --nodata-policy sustainable_current_carbon:-9999,0:0 --dry-run`

Closes #186