### PR TITLE
Fix #191: Bound WMS layers to raster extents

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1021,7 +1021,7 @@ function populateLayerSelects() {
  * Slots: 'base' (bottom), 'B' (middle), 'A' (top)
  * @param {string} qualifiedName
  * @param {'A'|'B'|'base'} slot
- * @param {{className?: string, transparent?: boolean, zIndex?: number}} [opts]
+ * @param {{className?: string, transparent?: boolean, zIndex?: number, bounds?: L.LatLngBounds}} [opts]
  */
 function addWmsLayer(qualifiedName, slot, opts = {}) {
   const wmsUrl = `${state.geoserverBaseUrl}/wms`;
@@ -1038,6 +1038,7 @@ function addWmsLayer(qualifiedName, slot, opts = {}) {
     className: opts.className ?? defaultClassName,
     noWrap: true,
     pane: paneBySlot[slot],
+    ...(opts.bounds ? { bounds: opts.bounds } : {}),
   });
 
   const stateKey = slot === "base" ? "wmsLayerBase" : `wmsLayer${slot}`;
@@ -1055,7 +1056,7 @@ function addWmsLayer(qualifiedName, slot, opts = {}) {
  * Adds/updates the base WMS underneath A/B when the base checkbox is checked.
  * @param {Event & {target: HTMLSelectElement}} e
  */
-function onBaseLayerChange(e) {
+async function onBaseLayerChange(e) {
   const idx = parseInt(e.target.value, 10);
   const baseLayer = state.availableBaseLayers[idx];
   if (!baseLayer) return;
@@ -1070,7 +1071,15 @@ function onBaseLayerChange(e) {
 
   const visibleCheckbox = document.getElementById("layerVisibleBase");
   if (visibleCheckbox) visibleCheckbox.checked = true;
-  addWmsLayer(baseLayer.name, "base", { className: "base-layer", zIndex: 100 });
+  let bounds = null;
+  try {
+    bounds = await _getWmsLayerLatLngBounds(baseLayer.name);
+  } catch {}
+  addWmsLayer(baseLayer.name, "base", {
+    className: "base-layer",
+    zIndex: 100,
+    bounds,
+  });
   state.baseVisibility = true;
   updateContextLegend();
 }
@@ -1202,9 +1211,7 @@ async function onLayerChange(e, layerId) {
   const isCategorical = isCategoricalLayer(lyr);
   const doInitialFit = !state.didInitialRasterFit && !!lyr?.name;
   if (doInitialFit) state.didInitialRasterFit = true;
-  const initialFitBoundsPromise = doInitialFit
-    ? _getWmsLayerLatLngBounds(lyr.name)
-    : null;
+  const layerBoundsPromise = lyr?.name ? _getWmsLayerLatLngBounds(lyr.name) : null;
   renderLayerMeta(layerId, lyr);
   setStyleControlsEnabled(layerId, !isCategorical);
 
@@ -1231,8 +1238,14 @@ async function onLayerChange(e, layerId) {
     : layerId === "A"
       ? "blend-screen"
       : "blend-base";
+  let bounds = null;
+  if (layerBoundsPromise) {
+    try {
+      bounds = await layerBoundsPromise;
+    } catch {}
+  }
   document.getElementById(`layerVisible${layerId}`).checked = true;
-  addWmsLayer(lyr.name, layerId, { className });
+  addWmsLayer(lyr.name, layerId, { className, bounds });
   if (!isCategorical) applyDynamicStyle(layerId);
   updateContextLegend();
   if (!state.sampleMode) {
@@ -1249,10 +1262,9 @@ async function onLayerChange(e, layerId) {
   const url = new URL(window.location.href);
   url.searchParams.set(`layer${layerId}`, state.availableLayers[idx].name);
   history.replaceState(null, "", url.toString());
-  if (initialFitBoundsPromise) {
+  if (doInitialFit && bounds) {
     try {
-      const b = await initialFitBoundsPromise;
-      if (b && b.isValid()) state.map.fitBounds(b, { padding: [24, 24] });
+      if (bounds.isValid()) state.map.fitBounds(bounds, { padding: [24, 24] });
     } catch {}
   }
 }

--- a/static/app.js
+++ b/static/app.js
@@ -663,13 +663,6 @@ async function loadConfig() {
   return res.json();
 }
 
-function withoutCrsWrapping(crs) {
-  const appCrs = Object.create(crs);
-  appCrs.wrapLng = undefined;
-  appCrs.wrapLat = undefined;
-  return appCrs;
-}
-
 /**
  * Initialize the Leaflet map and overlay event swallowing.
  * Side effects: sets state.map and wires overlay interactions.
@@ -677,7 +670,10 @@ function withoutCrsWrapping(crs) {
 function initMap(crsCode) {
   const baseLeafletCRS =
     L.CRS[String(crsCode).trim().toUpperCase().replace(":", "")];
-  const leafletCRS = withoutCrsWrapping(baseLeafletCRS);
+  const leafletCRS = Object.assign(Object.create(baseLeafletCRS), {
+    wrapLng: undefined,
+    wrapLat: undefined,
+  });
   const mapDiv = document.getElementById("map");
   const map = L.map(mapDiv, {
     crs: leafletCRS,
@@ -1049,7 +1045,7 @@ function addWmsLayer(qualifiedName, slot, opts = {}) {
     className: opts.className ?? defaultClassName,
     noWrap: true,
     pane: paneBySlot[slot],
-    ...(opts.bounds ? { bounds: opts.bounds } : {}),
+    bounds: opts.bounds ?? null,
   });
 
   const stateKey = slot === "base" ? "wmsLayerBase" : `wmsLayer${slot}`;
@@ -1084,6 +1080,7 @@ async function onBaseLayerChange(e) {
   if (visibleCheckbox) visibleCheckbox.checked = true;
   let bounds = null;
   try {
+    // Fetches WMS capabilities once; later calls read state._wmsLayerBoundsCache.
     bounds = await _getWmsLayerLatLngBounds(baseLayer.name);
   } catch {}
   addWmsLayer(baseLayer.name, "base", {
@@ -1219,10 +1216,12 @@ async function _getWmsLayerLatLngBounds(qualifiedName) {
 async function onLayerChange(e, layerId) {
   const idx = parseInt(e.target.value, 10);
   const lyr = state.availableLayers[idx];
+  if (!lyr) return;
+  const layerName = lyr.name;
   const isCategorical = isCategoricalLayer(lyr);
-  const doInitialFit = !state.didInitialRasterFit && !!lyr?.name;
+  const doInitialFit = !state.didInitialRasterFit;
   if (doInitialFit) state.didInitialRasterFit = true;
-  const layerBoundsPromise = lyr?.name ? _getWmsLayerLatLngBounds(lyr.name) : null;
+  const layerBoundsPromise = _getWmsLayerLatLngBounds(layerName);
   renderLayerMeta(layerId, lyr);
   setStyleControlsEnabled(layerId, !isCategorical);
 
@@ -1230,7 +1229,7 @@ async function onLayerChange(e, layerId) {
     const res = await fetch(`${state.baseStatsUrl}/stats/minmax`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ raster_id: lyr.name }),
+      body: JSON.stringify({ raster_id: layerName }),
     });
     if (!res.ok) throw new Error(await res.text());
     const { min_, max_ } = await res.json();
@@ -1256,7 +1255,7 @@ async function onLayerChange(e, layerId) {
     } catch {}
   }
   document.getElementById(`layerVisible${layerId}`).checked = true;
-  addWmsLayer(lyr.name, layerId, { className, bounds });
+  addWmsLayer(layerName, layerId, { className, bounds });
   if (!isCategorical) applyDynamicStyle(layerId);
   updateContextLegend();
   if (!state.sampleMode) {
@@ -1271,7 +1270,7 @@ async function onLayerChange(e, layerId) {
     sampleAndRenderSampleBox();
   }
   const url = new URL(window.location.href);
-  url.searchParams.set(`layer${layerId}`, state.availableLayers[idx].name);
+  url.searchParams.set(`layer${layerId}`, layerName);
   history.replaceState(null, "", url.toString());
   if (doInitialFit && bounds) {
     try {

--- a/static/app.js
+++ b/static/app.js
@@ -663,13 +663,21 @@ async function loadConfig() {
   return res.json();
 }
 
+function withoutCrsWrapping(crs) {
+  const appCrs = Object.create(crs);
+  appCrs.wrapLng = undefined;
+  appCrs.wrapLat = undefined;
+  return appCrs;
+}
+
 /**
  * Initialize the Leaflet map and overlay event swallowing.
  * Side effects: sets state.map and wires overlay interactions.
  */
 function initMap(crsCode) {
-  const leafletCRS =
+  const baseLeafletCRS =
     L.CRS[String(crsCode).trim().toUpperCase().replace(":", "")];
+  const leafletCRS = withoutCrsWrapping(baseLeafletCRS);
   const mapDiv = document.getElementById("map");
   const map = L.map(mapDiv, {
     crs: leafletCRS,
@@ -687,10 +695,13 @@ function initMap(crsCode) {
   map.getPane("blendPane").style.zIndex = 200;
   map.getPane("blendPane").style.isolation = "isolate";
   state.map = map;
-  if (Array.isArray(leafletCRS?.wrapLng) && leafletCRS?.projection?.bounds) {
-    const projectedBounds = leafletCRS.projection.bounds;
-    const southWest = leafletCRS.unproject(projectedBounds.min);
-    const northEast = leafletCRS.unproject(projectedBounds.max);
+  if (
+    Array.isArray(baseLeafletCRS?.wrapLng) &&
+    baseLeafletCRS?.projection?.bounds
+  ) {
+    const projectedBounds = baseLeafletCRS.projection.bounds;
+    const southWest = baseLeafletCRS.unproject(projectedBounds.min);
+    const northEast = baseLeafletCRS.unproject(projectedBounds.max);
     map.setMaxBounds(L.latLngBounds(southWest, northEast));
     map.options.maxBoundsViscosity = 1.0;
   }


### PR DESCRIPTION
## Summary
- Pass WMS capabilities bounds into Leaflet WMS tile layers when available.
- Apply the same bounds handling to A/B raster layers and base layers.
- Use a non-wrapping Leaflet CRS instance for the app so tile validation rejects columns outside the single world extent.
- Preserve the existing initial `fitBounds` behavior using the same fetched bounds.

## Verification
- `npm.cmd run build`

Fixes #191