### PR TITLE
Fix #193: Refactor controls into a docked map shell

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3134,7 +3134,7 @@ function wireControlGroup() {
   };
   const inputs = {
     window: [
-      group.querySelector("#windowSize"),
+      group.querySelector("#windowSlider"),
       group.querySelector("#windowSizeNumber"),
     ],
     shapefile: [group.querySelector("#shpInput")],
@@ -4220,54 +4220,59 @@ async function setSamplingMode(mode) {
 }
 
 /**
- * Initializes a collapsible top bar in the application header.
+ * Initializes the docked map shell and switches between control panels.
  *
- * This function binds click and resize event listeners to allow users
- * to toggle the visibility of the top bar section (`#topbarContent`)
- * using a button (`#headerToggle`). When expanded, the content smoothly
- * transitions to its full height; when collapsed, it animates closed.
- *
- * Behavior:
- * - Clicking the toggle button alternates between expanded and collapsed states.
- * - The header element gets the class `is-collapsed` when hidden.
- * - The button text and `aria-expanded` attribute are updated accordingly.
- * - On window resize, the expanded height readjusts to the content’s actual height.
- *
- * Requirements:
- * - The DOM must contain:
- *   - a `<header>` element,
- *   - a container with `id='topbarContent'`,
- *   - a toggle button with `id='headerToggle'`.
- *
- * Returns:
- *   void
+ * Layers, Style, and Sample panels share the same dock; the header toggle
+ * collapses the dock without removing the map from the viewport.
  */
-function wireCollapsibleTopBar() {
-  const header = document.querySelector("header");
+function wireMapShell() {
+  const header = document.querySelector(".map-shell");
   const content = document.getElementById("topbarContent");
   const toggle = document.getElementById("headerToggle");
+  const tabs = Array.from(document.querySelectorAll(".workspace-tab"));
+  const panels = Array.from(document.querySelectorAll(".workspace-panel"));
+  if (!header || !content || !toggle || !tabs.length || !panels.length) return;
+
+  const invalidateMapSize = () => {
+    requestAnimationFrame(() => state.map?.invalidateSize({ pan: false }));
+  };
+
+  const setActivePanel = (panelName) => {
+    tabs.forEach((tab) => {
+      const isSelected = tab.dataset.panel === panelName;
+      tab.classList.toggle("is-selected", isSelected);
+      tab.setAttribute("aria-pressed", String(isSelected));
+    });
+
+    panels.forEach((panel) => {
+      const isSelected = panel.dataset.panel === panelName;
+      panel.hidden = !isSelected;
+      panel.classList.toggle("is-active", isSelected);
+    });
+
+    invalidateMapSize();
+  };
 
   const setExpanded = (expanded) => {
-    if (expanded) {
-      content.style.maxHeight = content.scrollHeight + "px";
-      header.classList.remove("is-collapsed");
-      toggle.setAttribute("aria-expanded", "true");
-      toggle.textContent = "▲ Hide Control Panel";
-    } else {
-      content.style.maxHeight = "0px";
-      header.classList.add("is-collapsed");
-      toggle.setAttribute("aria-expanded", "false");
-      toggle.textContent = "▼ Show Control Panel";
-    }
+    header.classList.toggle("is-collapsed", !expanded);
+    toggle.setAttribute("aria-expanded", String(expanded));
+    toggle.textContent = expanded ? "Hide" : "Controls";
+    invalidateMapSize();
   };
 
   const onResize = () => {
-    if (toggle.getAttribute("aria-expanded") === "true") {
-      content.style.maxHeight = content.scrollHeight + "px";
-    }
+    invalidateMapSize();
   };
 
+  tabs.forEach((tab) => {
+    tab.addEventListener("click", () => {
+      setExpanded(true);
+      setActivePanel(tab.dataset.panel);
+    });
+  });
+
   setExpanded(true);
+  setActivePanel("layers");
   toggle.addEventListener("click", () => {
     const expanded = toggle.getAttribute("aria-expanded") === "true";
     setExpanded(!expanded);
@@ -4448,7 +4453,7 @@ function createBaseLegendControl() {
   wireShapefileAOIControl();
   wireControlGroup();
   wireOverlayControls();
-  wireCollapsibleTopBar();
+  wireMapShell();
   setSamplingMode("window");
 
   state.geoserverBaseUrl = cfg.geoserver_base_url;

--- a/static/style.css
+++ b/static/style.css
@@ -13,6 +13,7 @@
     --radius: 8px;
     --shadow-lg: 0 6px 20px rgba(0, 0, 0, 0.4);
     --shadow-md: 0 6px 18px rgba(0, 0, 0, 0.35);
+    --z-controls: 900;
     --z-overlay: 1000;
     --z-tooltip: 1001;
     --space-2: 8px;
@@ -44,9 +45,9 @@ body {
 }
 
 body {
-    display: flex;
-    flex-direction: column;
+    display: block;
     min-height: 100%;
+    overflow: hidden;
 }
 
 header {
@@ -61,8 +62,9 @@ header {
 }
 
 main {
-    flex: 1 1 auto;
-    min-height: 0;
+    position: fixed;
+    inset: 0;
+    min-height: 100%;
 }
 
 label {
@@ -99,6 +101,7 @@ input.num::-webkit-outer-spin-button {
 }
 
 .brand {
+    min-width: 0;
     font-weight: 700;
     color: var(--brand);
 }
@@ -185,15 +188,6 @@ input.num::-webkit-outer-spin-button {
     border-radius: 4px;
 }
 
-.controls-bar {
-    align-self: flex-start;
-    justify-content: flex-start;
-    gap: 20px;
-    flex-wrap: wrap;
-    display: flex;
-    margin-top: 0;
-}
-
 .control-group {
     background: var(--panel);
     padding: 10px 14px;
@@ -202,13 +196,14 @@ input.num::-webkit-outer-spin-button {
     display: flex;
     flex-direction: column;
     gap: 10px;
-    min-width: 280px;
+    min-width: 0;
+    width: 100%;
 }
 
 .control-group.layers,
 .control-group.style,
 .control-group.tools {
-    flex: 1;
+    flex: 0 0 auto;
 }
 
 .tool-section {
@@ -312,7 +307,7 @@ input.num::-webkit-outer-spin-button {
 }
 
 .style-panel {
-    margin-left: 0.75rem;
+    margin-left: 0;
     padding: 0.25rem 0.5rem;
     border: 1px solid var(--border);
     border-radius: 6px;
@@ -342,11 +337,6 @@ input.num::-webkit-outer-spin-button {
     grid-template-columns: 1fr;
     gap: 6px;
 }
-@media (max-width: 900px) {
-    .style-grid {
-        grid-template-columns: repeat(2, minmax(140px, 1fr));
-    }
-}
 
 .style-row {
     display: grid;
@@ -369,7 +359,7 @@ input.num::-webkit-outer-spin-button {
 
 #map {
     position: relative;
-    height: 100%;
+    height: 100vh;
     width: 100%;
     cursor: crosshair;
 }
@@ -384,9 +374,10 @@ input.num::-webkit-outer-spin-button {
 .overlay {
     position: absolute;
     top: 12px;
-    left: 12px;
+    right: 12px;
+    left: auto;
     z-index: var(--z-overlay);
-    width: min(960px, calc(100% - 24px));
+    width: min(960px, calc(100% - 420px));
     max-height: calc(100% - 24px);
     background: rgba(var(--bg-rgb), 0.96);
     border: 1px solid var(--border);
@@ -738,48 +729,113 @@ input.num::-webkit-outer-spin-button {
     min-height: 1.25em;
 }
 
-/* collapsible top bar */
-header {
-    position: relative;
-}
-
-.topbar-content {
-    overflow: hidden;
-    transition:
-        max-height 220ms ease,
-        opacity 200ms ease,
-        transform 200ms ease;
-    will-change: max-height, opacity, transform;
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-}
-
-.collapse-footer {
-    display: flex;
-    justify-content: center;
-    padding: 8px 0;
-    border-top: 1px solid var(--border);
-}
-
-.collapse-toggle {
-    background: var(--brand);
-    color: #081015;
-    font-weight: 600;
-    border: 1px solid var(--brand-hover);
+.map-shell {
+    position: fixed;
+    top: 12px;
+    left: 12px;
+    z-index: var(--z-controls);
+    width: min(360px, calc(100vw - 24px));
+    max-height: calc(100vh - 24px);
+    align-items: stretch;
+    gap: 8px;
+    padding: 10px;
+    border: 1px solid rgba(42, 47, 58, 0.95);
     border-radius: var(--radius);
-    cursor: pointer;
-    transition: background 0.2s ease;
-}
-.collapse-toggle:hover {
-    background: var(--brand-hover);
+    background: rgba(var(--panel-rgb), 0.96);
+    box-shadow: var(--shadow-md);
+    overflow: hidden;
+    pointer-events: auto;
 }
 
-header.is-collapsed .topbar-content {
-    max-height: 0 !important;
-    opacity: 0;
-    transform: translateY(-4px);
-    pointer-events: none;
+.shell-header {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px;
+    align-items: center;
+}
+
+.shell-header .brand {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.shell-toggle {
+    background: var(--input-bg);
+}
+
+.workspace-tabs {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 4px;
+}
+
+.workspace-tab {
+    appearance: none;
+    min-width: 0;
+    padding: 7px 8px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--input-bg);
+    color: var(--fg);
+    cursor: pointer;
+    font: inherit;
+    font-size: 13px;
+}
+
+.workspace-tab:hover {
+    border-color: var(--brand);
+    color: var(--brand-hover);
+}
+
+.workspace-tab.is-selected {
+    background: var(--brand);
+    border-color: var(--brand-hover);
+    color: #081015;
+}
+
+.workspace-panels {
+    max-height: calc(100vh - 132px);
+    overflow: auto;
+}
+
+.workspace-panel[hidden] {
+    display: none;
+}
+
+.workspace-panel.is-active {
+    display: flex;
+}
+
+.map-shell.is-collapsed {
+    width: auto;
+}
+
+.map-shell.is-collapsed .workspace-tabs,
+.map-shell.is-collapsed .topbar-content {
+    display: none;
+}
+
+.map-shell select {
+    width: 100%;
+    min-width: 0;
+}
+
+.map-shell .tool-description {
+    font-size: 12px;
+}
+
+#samplingPanel .tool-description {
+    display: none;
+}
+
+#samplingPanel .tool-section {
+    margin-bottom: 4px;
+}
+
+#samplingPanel .export-actions {
+    align-items: stretch;
+    flex-direction: column;
 }
 
 .layer-label {
@@ -1056,4 +1112,30 @@ header.is-collapsed .topbar-content {
   font-size: 11px;
   color: #94a3b8;
   line-height: 1;
+}
+
+@media (max-width: 1100px) {
+    .overlay {
+        top: auto;
+        right: 12px;
+        bottom: 12px;
+        width: calc(100% - 24px);
+        max-height: min(58vh, calc(100% - 24px));
+    }
+}
+
+@media (max-width: 640px) {
+    .map-shell {
+        right: 12px;
+        width: auto;
+        max-height: min(52vh, calc(100vh - 24px));
+    }
+
+    .workspace-panels {
+        max-height: calc(52vh - 120px);
+    }
+
+    .layer-label {
+        font-size: 13px;
+    }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -374,8 +374,7 @@ input.num::-webkit-outer-spin-button {
 .overlay {
     position: absolute;
     top: 12px;
-    right: 12px;
-    left: auto;
+    left: 12px;
     z-index: var(--z-overlay);
     width: min(960px, calc(100% - 420px));
     max-height: calc(100% - 24px);
@@ -732,7 +731,7 @@ input.num::-webkit-outer-spin-button {
 .map-shell {
     position: fixed;
     top: 12px;
-    left: 12px;
+    right: 12px;
     z-index: var(--z-controls);
     width: min(360px, calc(100vw - 24px));
     max-height: calc(100vh - 24px);
@@ -1117,7 +1116,7 @@ input.num::-webkit-outer-spin-button {
 @media (max-width: 1100px) {
     .overlay {
         top: auto;
-        right: 12px;
+        left: 12px;
         bottom: 12px;
         width: calc(100% - 24px);
         max-height: min(58vh, calc(100% - 24px));
@@ -1126,6 +1125,7 @@ input.num::-webkit-outer-spin-button {
 
 @media (max-width: 640px) {
     .map-shell {
+        left: 12px;
         right: 12px;
         width: auto;
         max-height: min(52vh, calc(100vh - 24px));

--- a/templates/index.html
+++ b/templates/index.html
@@ -54,178 +54,221 @@
     {% endfor %}
   </head>
   <body>
-    <header>
-      <div class="brand">
-        {{ app_title }}
-        <span id="appVersion" class="tool-description">{{ app_version }}</span>
+    <header class="map-shell">
+      <div class="shell-header">
+        <div class="brand">
+          {{ app_title }}
+          <span id="appVersion" class="tool-description">{{ app_version }}</span>
+        </div>
+        <button
+          id="headerToggle"
+          class="btn small shell-toggle"
+          type="button"
+          aria-expanded="true"
+          aria-controls="topbarContent"
+        >
+          Hide
+        </button>
       </div>
-      <div id="topbarContent" class="topbar-content">
-        <div class="controls-bar">
-          {% macro layer_group(layer_id, label_text, default_value='',
-          show_checked=true, extra_class='') %}
-          <div id="layerGroup{{ layer_id }}" class="layer-group {{ extra_class }}">
-            <label class="layer-label">{{ label_text }}</label>
-            <select
-              id="layerSelect{{ layer_id }}"
-              data-default="{{ default_value }}"
-            ></select>
-            <label class="vis-label">
-              <input
-                id="layerVisible{{ layer_id }}"
-                type="checkbox"
-                {%
-                if
-                show_checked
-                %}checked{%
-                endif
-                %}
-              />
-              <span>Show</span>
-            </label>
-          </div>
-          {% endmacro %}
-          <div class="control-group layers">
-            {% for layer_id in ['A', 'B'] %} {{ layer_group( layer_id, 'Select a
-            layer to display (' ~ layer_id ~ ')', initial_layers.get(layer_id, ''),
-            true ) }} {% endfor %} {{ layer_group(
-            'Base', 'Select a base layer to display', initial_layers.get('Base',
-            ''), true, 'hidden' ) }}
-          </div>
 
-          <div class="control-group style">
-            {% for layer_id in ['A', 'B'] %}
-            <details class="style-panel">
-              <summary>Style {{ layer_id }}</summary>
-              <div class="style-grid">
-                <div class="style-row">
-                  <label>Min</label>
-                  <input
-                    id="layer{{ layer_id }}MinInput"
-                    type="number"
-                    step="any"
-                  />
-                  <input id="layer{{ layer_id }}CminInput" type="color" />
-                </div>
-                <div class="style-row">
-                  <label>Med</label>
-                  <input
-                    id="layer{{ layer_id }}MedInput"
-                    type="number"
-                    step="any"
-                  />
-                  <input id="layer{{ layer_id }}CmedInput" type="color" />
-                </div>
-                <div class="style-row">
-                  <label>Max</label>
-                  <input
-                    id="layer{{ layer_id }}MaxInput"
-                    type="number"
-                    step="any"
-                  />
-                  <input id="layer{{ layer_id }}CmaxInput" type="color" />
-                </div>
+      <div class="workspace-tabs" role="tablist" aria-label="Viewer panels">
+        <button
+          type="button"
+          class="workspace-tab is-selected"
+          data-panel="layers"
+          aria-controls="layersPanel"
+          aria-pressed="true"
+        >
+          Layers
+        </button>
+        <button
+          type="button"
+          class="workspace-tab"
+          data-panel="style"
+          aria-controls="stylePanel"
+          aria-pressed="false"
+        >
+          Style
+        </button>
+        <button
+          type="button"
+          class="workspace-tab"
+          data-panel="sample"
+          aria-controls="samplingPanel"
+          aria-pressed="false"
+        >
+          Sample
+        </button>
+      </div>
+
+      <div id="topbarContent" class="topbar-content workspace-panels">
+        {% macro layer_group(layer_id, label_text, default_value='',
+        show_checked=true, extra_class='') %}
+        <div id="layerGroup{{ layer_id }}" class="layer-group {{ extra_class }}">
+          <label class="layer-label">{{ label_text }}</label>
+          <select
+            id="layerSelect{{ layer_id }}"
+            data-default="{{ default_value }}"
+          ></select>
+          <label class="vis-label">
+            <input
+              id="layerVisible{{ layer_id }}"
+              type="checkbox"
+              {%
+              if
+              show_checked
+              %}checked{%
+              endif
+              %}
+            />
+            <span>Show</span>
+          </label>
+        </div>
+        {% endmacro %}
+
+        <section
+          id="layersPanel"
+          class="control-group layers workspace-panel is-active"
+          data-panel="layers"
+        >
+          {% for layer_id in ['A', 'B'] %} {{ layer_group( layer_id, 'Select a
+          layer to display (' ~ layer_id ~ ')', initial_layers.get(layer_id, ''),
+          true ) }} {% endfor %} {{ layer_group(
+          'Base', 'Select a base layer to display', initial_layers.get('Base',
+          ''), true, 'hidden' ) }}
+        </section>
+
+        <section
+          id="stylePanel"
+          class="control-group style workspace-panel"
+          data-panel="style"
+          hidden
+        >
+          {% for layer_id in ['A', 'B'] %}
+          <details class="style-panel">
+            <summary>Style {{ layer_id }}</summary>
+            <div class="style-grid">
+              <div class="style-row">
+                <label>Min</label>
+                <input
+                  id="layer{{ layer_id }}MinInput"
+                  type="number"
+                  step="any"
+                />
+                <input id="layer{{ layer_id }}CminInput" type="color" />
               </div>
-            </details>
-            {% endfor %}
-            <div class="palette-control">
-              <label>
-                Palette
-                <select id="bivariatePaletteSelect"></select>
-              </label>
+              <div class="style-row">
+                <label>Med</label>
+                <input
+                  id="layer{{ layer_id }}MedInput"
+                  type="number"
+                  step="any"
+                />
+                <input id="layer{{ layer_id }}CmedInput" type="color" />
+              </div>
+              <div class="style-row">
+                <label>Max</label>
+                <input
+                  id="layer{{ layer_id }}MaxInput"
+                  type="number"
+                  step="any"
+                />
+                <input id="layer{{ layer_id }}CmaxInput" type="color" />
+              </div>
             </div>
-            <label for="applyAutoStyleBtn">
-              Sets Layer A and B color thresholds to the histogram's min and max
-              percentile values.
+          </details>
+          {% endfor %}
+          <div class="palette-control">
+            <label>
+              Palette
+              <select id="bivariatePaletteSelect"></select>
             </label>
-            <button class="btn small" id="applyAutoStyleBtn">
-              Apply Percentile Range
+          </div>
+          <label for="applyAutoStyleBtn">
+            Sets Layer A and B color thresholds to the histogram's min and max
+            percentile values.
+          </label>
+          <button class="btn small" id="applyAutoStyleBtn">
+            Apply Percentile Range
+          </button>
+        </section>
+
+        <section
+          id="samplingPanel"
+          class="control-group tools workspace-panel"
+          data-panel="sample"
+          data-mode="window"
+          hidden
+        >
+          <div
+            class="tool-toggle"
+            role="radiogroup"
+            aria-label="Sampling mode"
+          >
+            <button
+              type="button"
+              class="mode-btn is-selected"
+              data-mode="window"
+              aria-pressed="true"
+            >
+              Window
+            </button>
+            <button
+              type="button"
+              class="mode-btn"
+              data-mode="shapefile"
+              aria-pressed="false"
+            >
+              Shapefile
             </button>
           </div>
 
-          <div class="controls-bar">
-            <div class="control-group tools" data-mode="window">
-              <div
-                class="tool-toggle"
-                role="radiogroup"
-                aria-label="Sampling mode"
-              >
-                <button
-                  type="button"
-                  class="mode-btn is-selected"
-                  data-mode="window"
-                  aria-pressed="true"
-                >
-                  Window
-                </button>
-                <button
-                  type="button"
-                  class="mode-btn"
-                  data-mode="shapefile"
-                  aria-pressed="false"
-                >
-                  Shapefile
-                </button>
-              </div>
-
-              <div class="tool-section" data-section="window">
-                <label class="tool-label">Histogram Sampling Box</label>
-                <p class="tool-description">
-                  A square window of this size (in kilometers) follows your
-                  mouse to compute scatterplot statistics.
-                </p>
-                <div class="window-size">
-                  <label for="windowSlider">Size (km)</label>
-                  <input
-                    id="windowSlider"
-                    type="range"
-                  />
-                  <input id="windowSizeNumber" class="num" type="number" />
-                </div>
-              </div>
-
-              <div class="tool-section" data-section="shapefile">
-                <label class="tool-label" for="shpInput"
-                  >Upload Area of Interest (.zip shapefile)</label
-                >
-                <p class="tool-description">
-                  If uploaded, the shapefile defines the area for histogram and
-                  scatterplot stats, overriding the moving window.
-                </p>
-                <input id="shpInput" type="file" accept=".zip" />
-              </div>
-
-              <div class="tool-section" data-section="export">
-                <p class="tool-description">
-                  Download the raster layer(s) clipped to the current window or
-                  uploaded area.
-                </p>
-                <div class="export-actions">
-                  <button
-                    type="button"
-                    id="exportAreaBtn"
-                    class="btn solid export-btn disabled"
-                    aria-label="Download Sampling Area"
-                  >
-                    Download disabled: select area on map
-                  </button>
-                  <span
-                    id="exportStatus"
-                    class="small-mono muted"
-                    aria-live="polite"
-                  ></span>
-                </div>
-              </div>
+          <div class="tool-section" data-section="window">
+            <label class="tool-label">Histogram Sampling Box</label>
+            <p class="tool-description">
+              A square window of this size (in kilometers) follows your
+              mouse to compute scatterplot statistics.
+            </p>
+            <div class="window-size">
+              <label for="windowSlider">Size (km)</label>
+              <input id="windowSlider" type="range" />
+              <input id="windowSizeNumber" class="num" type="number" />
             </div>
           </div>
-        </div>
-      </div>
-      <div class="collapse-footer">
-        <button
-          id="headerToggle"
-          class="btn small collapse-toggle"
-          aria-expanded="true"
-          aria-controls="topbarContent"
-        ></button>
+
+          <div class="tool-section" data-section="shapefile">
+            <label class="tool-label" for="shpInput"
+              >Upload Area of Interest (.zip shapefile)</label
+            >
+            <p class="tool-description">
+              If uploaded, the shapefile defines the area for histogram and
+              scatterplot stats, overriding the moving window.
+            </p>
+            <input id="shpInput" type="file" accept=".zip" />
+          </div>
+
+          <div class="tool-section" data-section="export">
+            <p class="tool-description">
+              Download the raster layer(s) clipped to the current window or
+              uploaded area.
+            </p>
+            <div class="export-actions">
+              <button
+                type="button"
+                id="exportAreaBtn"
+                class="btn solid export-btn disabled"
+                aria-label="Download Sampling Area"
+              >
+                Download disabled: select area on map
+              </button>
+              <span
+                id="exportStatus"
+                class="small-mono muted"
+                aria-live="polite"
+              ></span>
+            </div>
+          </div>
+        </section>
       </div>
     </header>
 


### PR DESCRIPTION
## Summary
- Replace the wide horizontal control bar with a docked map shell.
- Split controls into Layers, Style, and Sample panels while preserving existing control IDs and behavior.
- Keep layer selection as the default visible workflow and make style/sampling optional panels.
- Move the area sampler overlay to the right side on wide screens so it remains prominent without covering the dock.
- Compact the sampling panel and fix its window slider lookup to use `#windowSlider`.

## Verification
- `npm.cmd run build`
- `git diff --check`

Notes: I was not able to visually inspect the running app in the in-app browser because the browser connector failed to start in this sandbox. This should get a manual visual pass before marking ready.

Fixes #193