### PR TITLE
Fix #195: Tighten area sampler report layout

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2954,11 +2954,16 @@ function buildScatterSVG(xEdges, yEdges, hist2d, opts = {}) {
 
     const label = mkText(
       `${Math.round(percentile * 100)}% (${value.toFixed(percentileDecimals)})`,
-      plotX1 + mSize + 4,
-      y + 3,
-      'start',
+      plotX1 + mSize + 8,
+      y,
+      'middle',
     );
     label.setAttribute('fill', percentileColor);
+    label.setAttribute('dominant-baseline', 'middle');
+    label.setAttribute(
+      'transform',
+      `rotate(-90 ${plotX1 + mSize + 8} ${y})`,
+    );
     svg.appendChild(label);
 
     attachPctHover(

--- a/static/app.js
+++ b/static/app.js
@@ -2066,7 +2066,7 @@ function appendSampleSummaryCard(container, rasterId, summary) {
   const title = document.createElement('div');
   title.className = 'sample-summary-title';
   title.textContent = rasterId;
-  title.title = rasterId;
+  title.setAttribute('title', rasterId);
   card.appendChild(title);
 
   [
@@ -2109,7 +2109,7 @@ function appendCategoricalSummaryCard(container, rasterId, categories) {
   const title = document.createElement('div');
   title.className = 'sample-summary-title';
   title.textContent = rasterId;
-  title.title = rasterId;
+  title.setAttribute('title', rasterId);
   card.appendChild(title);
 
   const list = document.createElement('div');

--- a/static/app.js
+++ b/static/app.js
@@ -2066,6 +2066,7 @@ function appendSampleSummaryCard(container, rasterId, summary) {
   const title = document.createElement('div');
   title.className = 'sample-summary-title';
   title.textContent = rasterId;
+  title.title = rasterId;
   card.appendChild(title);
 
   [
@@ -2108,6 +2109,7 @@ function appendCategoricalSummaryCard(container, rasterId, categories) {
   const title = document.createElement('div');
   title.className = 'sample-summary-title';
   title.textContent = rasterId;
+  title.title = rasterId;
   card.appendChild(title);
 
   const list = document.createElement('div');
@@ -2190,6 +2192,12 @@ function renderSampleSummary(scatterObj, opts) {
   }
 }
 
+function compactAxisLabel(label, maxLength = 34) {
+  const text = String(label || "");
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength - 1)}…`;
+}
+
 /**
  * Render a scatterplot of two rasters' values within a polygon.
  * @param {{rasterX:string,rasterY:string,centerLng:number,centerLat:number,boxKm:number,scatterObj:object}} args
@@ -2226,7 +2234,7 @@ async function renderScatterOverlay(opts) {
 
   if (needsBodyRefresh) {
     body.innerHTML = `
-      <div class='overlay-header'>
+      <div class='sample-report-header'>
         <div>
           <div class='overlay-title'>${plotTitleHtml}</div>
           <div class='small-mono'>sample area: ${fmt(boxKm)} km / ${centerHtml}</div>
@@ -2240,15 +2248,17 @@ async function renderScatterOverlay(opts) {
           </div>
           <div id='sampleSummary' class='sample-summary'></div>
         </div>
-        <div id='histogramControls' class='layer-group'>
-          <label class='tool-label' for='percentiles'>Histogram Percentiles</label>
-          <p class='tool-description'>Draw percentile threshold lines at (e.g., 10, 50, 90).</p>
-          <input id='percentiles' type='text' value="${state.percentiles}"/>
-        </div>
-        <div id='plotRangeGroup' class='layer-group'>
-          <label class='tool-label'>Plot Range</label>
-          <p class='tool-description'>Zoom the current histogram or scatter view without re-sampling.</p>
-          <div id='plotRangeControls'></div>
+        <div class='sample-advanced-controls'>
+          <details id='histogramControls' class='layer-group sample-control-details'>
+            <summary>Histogram Percentiles</summary>
+            <p class='tool-description'>Draw percentile threshold lines at (e.g., 10, 50, 90).</p>
+            <input id='percentiles' type='text' value="${state.percentiles}"/>
+          </details>
+          <details id='plotRangeGroup' class='layer-group sample-control-details'>
+            <summary>Plot Range</summary>
+            <p class='tool-description'>Zoom the current histogram or scatter view without re-sampling.</p>
+            <div id='plotRangeControls'></div>
+          </details>
         </div>
       </div>
     `;
@@ -2354,14 +2364,15 @@ async function renderScatterOverlay(opts) {
       {
         width: 420,
         height: 320,
-        pad: 40,
+        pad: 32,
+        marginalSize: 42,
         percentiles: state.percentiles,
         layerIdX: 'A',
         layerIdY: 'B',
         blend: 'plus-lighter',
         point: state.lastPixelPoint,
-        axisLabelX: rasterX,
-        axisLabelY: rasterY,
+        axisLabelX: compactAxisLabel(rasterX),
+        axisLabelY: compactAxisLabel(rasterY),
         viewXMin: state.plotView.xMin,
         viewXMax: state.plotView.xMax,
         viewYMin: state.plotView.yMin,
@@ -2372,13 +2383,15 @@ async function renderScatterOverlay(opts) {
     svg = buildHistogramSVG(scatterObj.x_edges, scatterObj.hist1d_x, 'A', {
       viewMin: state.plotView.xMin,
       viewMax: state.plotView.xMax,
-      axisLabel: rasterX,
+      axisLabel: compactAxisLabel(rasterX, 42),
+      pad: 28,
     });
   } else if (has1DY) {
     svg = buildHistogramSVG(scatterObj.y_edges, scatterObj.hist1d_y, 'B', {
       viewMin: state.plotView.yMin,
       viewMax: state.plotView.yMax,
-      axisLabel: rasterY,
+      axisLabel: compactAxisLabel(rasterY, 42),
+      pad: 28,
     });
   }
 

--- a/static/app.js
+++ b/static/app.js
@@ -2234,14 +2234,13 @@ async function renderScatterOverlay(opts) {
 
   if (needsBodyRefresh) {
     body.innerHTML = `
-      <div class='sample-report-header'>
-        <div>
-          <div class='overlay-title'>${plotTitleHtml}</div>
-          <div class='small-mono'>sample area: ${fmt(boxKm)} km / ${centerHtml}</div>
+      <div class='overlay-content sample-report-shell'>
+        <div class='sample-report-header'>
+          <div>
+            <div class='overlay-title'>${plotTitleHtml}</div>
+            <div class='small-mono'>sample area: ${fmt(boxKm)} km / ${centerHtml}</div>
+          </div>
         </div>
-      </div>
-
-      <div class='overlay-content'>
         <div class='plot-report-layout'>
           <div id='scatterPlot' class='plot-holder'>
             ${hasData ? '' : '<div class="spinner" aria-label="loading"></div>'}

--- a/static/style.css
+++ b/static/style.css
@@ -494,7 +494,7 @@ input.num::-webkit-outer-spin-button {
 
 .plot-report-layout {
     display: grid;
-    grid-template-columns: minmax(420px, max-content) minmax(260px, 340px);
+    grid-template-columns: minmax(420px, max-content) max-content;
     gap: 10px;
     align-items: start;
     justify-content: start;
@@ -508,6 +508,8 @@ input.num::-webkit-outer-spin-button {
     display: grid;
     gap: 6px;
     min-width: 0;
+    width: max-content;
+    max-width: min(340px, 100%);
 }
 
 .sample-summary-card,
@@ -659,6 +661,7 @@ input.num::-webkit-outer-spin-button {
     }
 
     .sample-summary {
+        width: 100%;
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     }
 
@@ -677,6 +680,7 @@ input.num::-webkit-outer-spin-button {
     }
 
     .sample-summary {
+        width: 100%;
         grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -376,7 +376,9 @@ input.num::-webkit-outer-spin-button {
     top: 12px;
     left: 12px;
     z-index: var(--z-overlay);
-    width: min(960px, calc(100% - 420px));
+    width: fit-content;
+    min-width: min(720px, calc(100% - 420px));
+    max-width: calc(100% - 420px);
     max-height: calc(100% - 24px);
     background: rgba(var(--bg-rgb), 0.96);
     border: 1px solid var(--border);
@@ -419,6 +421,8 @@ input.num::-webkit-outer-spin-button {
 .overlay-body {
     padding: var(--space-3);
     overflow: auto;
+    width: max-content;
+    max-width: 100%;
 }
 .overlay-body pre {
     margin: 0 0 var(--space-2) 0;
@@ -466,6 +470,8 @@ input.num::-webkit-outer-spin-button {
     display: grid;
     grid-template-columns: 1fr !important;
     gap: var(--space-2);
+    width: max-content;
+    max-width: 100%;
 }
 
 .stats-grid {
@@ -628,6 +634,8 @@ input.num::-webkit-outer-spin-button {
 .sample-advanced-controls {
     display: grid;
     gap: 6px;
+    width: 100%;
+    max-width: 100%;
 }
 
 .sample-control-details {
@@ -1170,8 +1178,14 @@ input.num::-webkit-outer-spin-button {
         top: auto;
         left: 12px;
         bottom: 12px;
+        min-width: 0;
         width: calc(100% - 24px);
         max-height: min(58vh, calc(100% - 24px));
+    }
+
+    .overlay-body,
+    .overlay-content {
+        width: auto;
     }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -376,8 +376,8 @@ input.num::-webkit-outer-spin-button {
     top: 12px;
     left: 12px;
     z-index: var(--z-overlay);
-    width: fit-content;
-    min-width: min(720px, calc(100% - 420px));
+    width: max-content;
+    min-width: 0;
     max-width: calc(100% - 420px);
     max-height: calc(100% - 24px);
     background: rgba(var(--bg-rgb), 0.96);
@@ -421,7 +421,7 @@ input.num::-webkit-outer-spin-button {
 .overlay-body {
     padding: var(--space-3);
     overflow: auto;
-    width: max-content;
+    width: auto;
     max-width: 100%;
 }
 .overlay-body pre {
@@ -470,6 +470,14 @@ input.num::-webkit-outer-spin-button {
     display: grid;
     grid-template-columns: 1fr !important;
     gap: var(--space-2);
+    width: auto;
+    max-width: 100%;
+}
+
+.sample-report-shell {
+    display: inline-grid;
+    grid-template-columns: max-content;
+    justify-items: stretch;
     width: max-content;
     max-width: 100%;
 }
@@ -634,7 +642,7 @@ input.num::-webkit-outer-spin-button {
 .sample-advanced-controls {
     display: grid;
     gap: 6px;
-    width: 100%;
+    width: auto;
     max-width: 100%;
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -465,7 +465,7 @@ input.num::-webkit-outer-spin-button {
 .overlay-content {
     display: grid;
     grid-template-columns: 1fr !important;
-    gap: var(--space-3);
+    gap: var(--space-2);
 }
 
 .stats-grid {
@@ -493,21 +493,20 @@ input.num::-webkit-outer-spin-button {
 }
 
 .plot-report-layout {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-3);
+    display: grid;
+    grid-template-columns: minmax(420px, max-content) minmax(260px, 340px);
+    gap: 10px;
     align-items: start;
+    justify-content: start;
 }
 
 .plot-report-layout .plot-holder {
-    flex: 1 1 520px;
-    min-width: min(100%, 360px);
+    min-width: 0;
 }
 
 .sample-summary {
     display: grid;
-    flex: 0 1 340px;
-    gap: var(--space-2);
+    gap: 6px;
     min-width: 0;
 }
 
@@ -516,7 +515,7 @@ input.num::-webkit-outer-spin-button {
     border: 1px solid var(--border);
     border-radius: 6px;
     background: rgba(15, 23, 42, 0.48);
-    padding: var(--space-2);
+    padding: 8px 10px;
 }
 
 .sample-summary-title {
@@ -524,17 +523,21 @@ input.num::-webkit-outer-spin-button {
     font-size: 12px;
     font-weight: 700;
     line-height: 1.2;
+    margin-bottom: 6px;
+    display: -webkit-box;
+    overflow: hidden;
     overflow-wrap: anywhere;
-    margin-bottom: var(--space-2);
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
 }
 
 .sample-summary-row {
     display: grid;
-    grid-template-columns: max-content minmax(0, 1fr);
-    gap: var(--space-2);
+    grid-template-columns: minmax(0, 1fr) max-content;
+    gap: 8px;
     align-items: baseline;
     font-size: 12px;
-    line-height: 1.45;
+    line-height: 1.3;
 }
 
 .sample-summary-label {
@@ -598,8 +601,8 @@ input.num::-webkit-outer-spin-button {
 
 #scatterPlot {
     display: flex;
-    justify-content: center;
-    align-items: center;
+    justify-content: flex-start;
+    align-items: flex-start;
 }
 #scatterPlot svg {
     max-width: 100%;
@@ -614,13 +617,48 @@ input.num::-webkit-outer-spin-button {
     vector-effect: non-scaling-stroke;
 }
 
+.sample-report-header {
+    border-bottom: 1px solid var(--border);
+    background: rgba(var(--panel-rgb), 0.72);
+    padding: 10px 14px;
+}
+
+.sample-advanced-controls {
+    display: grid;
+    gap: 6px;
+}
+
+.sample-control-details {
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: rgba(15, 23, 42, 0.38);
+    padding: 0;
+}
+
+.sample-control-details summary {
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 700;
+    padding: 8px 10px;
+    color: var(--fg);
+}
+
+.sample-control-details .tool-description,
+.sample-control-details input,
+.sample-control-details #plotRangeControls {
+    margin: 0 10px 10px;
+}
+
 @media (max-width: 760px) {
+    .plot-report-layout {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
     .plot-report-layout .plot-holder {
         min-width: 0;
     }
 
     .sample-summary {
-        flex-basis: 100%;
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     }
 
@@ -630,6 +668,16 @@ input.num::-webkit-outer-spin-button {
 
     .sample-summary-label {
         white-space: normal;
+    }
+}
+
+@media (min-width: 761px) and (max-width: 980px) {
+    .plot-report-layout {
+        grid-template-columns: minmax(0, max-content);
+    }
+
+    .sample-summary {
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     }
 }
 


### PR DESCRIPTION
## Summary
- Refactor the sampler overlay body into a tighter report-style layout.
- Left-align the plot and reduce the plot/report gap.
- Make summary cards denser and clamp long raster names while preserving full names as tooltips.
- Collapse Histogram Percentiles and Plot Range into details controls.
- Shorten long axis labels and reduce plot padding/marginal chart size.

## Verification
- `npm.cmd run build`
- `git diff --check`

Notes: I could not visually inspect the running app in the in-app browser because the browser connector failed to start in this sandbox. This should get a manual visual pass before marking ready.

Fixes #195