### PR TITLE
Fix EPSG:8857 layer bounds and GeoServer CRS WKT

### DIFF
--- a/geoserver_register.py
+++ b/geoserver_register.py
@@ -307,14 +307,14 @@ def crs_info_from_rasterio_crs(crs):
     if auth == "EPSG" and code:
         return {
             "declared_srs": f"EPSG:{code}",
-            "native_wkt": crs.to_wkt(version="WKT1_GDAL"),
+            "native_wkt": None,
             "policy": "FORCE_DECLARED",
         }
     else:
         # choose a declared CRS you want clients to see (e.g., EPSG:4326)
         return {
             "declared_srs": "EPSG:4326",
-            "native_wkt": crs.to_wkt(version="WKT1_GDAL"),
+            "native_wkt": crs.to_wkt(),
             "policy": "REPROJECT_TO_DECLARED",
         }
 
@@ -380,7 +380,6 @@ def create_layer(
             "enabled": True,
             "projectionPolicy": info["policy"],
             "srs": info["declared_srs"],
-            "nativeCRS": info["native_wkt"],
             # These are hard-coded to allow common requests and responses in
             # common web and geographic CRSs EPSG:4326 (lat/lon) and
             # EPSG:3857 (Web Mercator) without allowing just any projection
@@ -390,6 +389,8 @@ def create_layer(
             "responseSRS": {"string": ["EPSG:3857"]},
         }
     }
+    if info["native_wkt"]:
+        coverage_payload["coverage"]["nativeCRS"] = info["native_wkt"]
 
     coverage_response = geoserver_client.post(
         f"/rest/workspaces/{workspace_name}/coveragestores"

--- a/geoserver_register.py
+++ b/geoserver_register.py
@@ -307,14 +307,14 @@ def crs_info_from_rasterio_crs(crs):
     if auth == "EPSG" and code:
         return {
             "declared_srs": f"EPSG:{code}",
-            "native_wkt": crs.to_wkt(),
+            "native_wkt": crs.to_wkt(version="WKT1_GDAL"),
             "policy": "FORCE_DECLARED",
         }
     else:
         # choose a declared CRS you want clients to see (e.g., EPSG:4326)
         return {
             "declared_srs": "EPSG:4326",
-            "native_wkt": crs.to_wkt(),
+            "native_wkt": crs.to_wkt(version="WKT1_GDAL"),
             "policy": "REPROJECT_TO_DECLARED",
         }
 

--- a/history.rst
+++ b/history.rst
@@ -8,6 +8,8 @@ Unreleased
 * Fixed EPSG:8857 layer startup by preferring geographic WMS bounds in the
   viewer and avoiding WKT native CRS metadata when GeoServer can use an EPSG
   authority code during registration.
+* Prevented low-zoom EPSG:8857 WMS tile candidates outside the projection
+  domain from crashing layer creation.
 
 1.5.0 (2026-06-09)
 ------------------

--- a/history.rst
+++ b/history.rst
@@ -6,7 +6,8 @@ Unreleased
 * Added frontend EPSG:8857 map CRS support and a visible unsupported-CRS
   startup message.
 * Fixed EPSG:8857 layer startup by preferring geographic WMS bounds in the
-  viewer and sending GeoServer WKT1 native CRS metadata during registration.
+  viewer and avoiding WKT native CRS metadata when GeoServer can use an EPSG
+  authority code during registration.
 
 1.5.0 (2026-06-09)
 ------------------

--- a/history.rst
+++ b/history.rst
@@ -5,6 +5,8 @@ Unreleased
 ----------
 * Added frontend EPSG:8857 map CRS support and a visible unsupported-CRS
   startup message.
+* Fixed EPSG:8857 layer startup by preferring geographic WMS bounds in the
+  viewer and sending GeoServer WKT1 native CRS metadata during registration.
 
 1.5.0 (2026-06-09)
 ------------------

--- a/history.rst
+++ b/history.rst
@@ -10,6 +10,8 @@ Unreleased
   authority code during registration.
 * Prevented low-zoom EPSG:8857 WMS tile candidates outside the projection
   domain from crashing layer creation.
+* Increased the EPSG:8857 zoom-zero pixel width so normal desktop viewports do
+  not start outside the valid Equal Earth projection domain.
 
 1.5.0 (2026-06-09)
 ------------------

--- a/static/app.js
+++ b/static/app.js
@@ -1134,6 +1134,7 @@ function addWmsLayer(qualifiedName, slot, opts = {}) {
     pane: paneBySlot[slot],
     bounds: opts.bounds ?? null,
   });
+  suppressInvalidProjectedTileBounds(layer);
 
   const stateKey = slot === "base" ? "wmsLayerBase" : `wmsLayer${slot}`;
   if (state[stateKey]) state.map.removeLayer(state[stateKey]);
@@ -1251,6 +1252,31 @@ function _latLngBoundsOrNull(southWest, northEast) {
     }
   } catch {}
   return null;
+}
+
+/**
+ * Prevent custom projected CRS tile bounds from crashing WMS layer creation.
+ *
+ * Leaflet checks tile bounds by unprojecting tile corners. At low zoom levels,
+ * custom projections such as EPSG:8857 can produce candidate tiles outside the
+ * projection's valid domain before Leaflet has a chance to reject them against
+ * the layer bounds. Treat those tiles as invalid and let valid tiles continue
+ * through Leaflet's normal checks.
+ *
+ * @param {L.TileLayer.WMS} layer - WMS layer to protect.
+ */
+function suppressInvalidProjectedTileBounds(layer) {
+  const originalIsValidTile = layer._isValidTile;
+  layer._isValidTile = function (coords) {
+    try {
+      return originalIsValidTile.call(this, coords);
+    } catch (error) {
+      if (String(error?.message || "").includes("Invalid LatLng object")) {
+        return false;
+      }
+      throw error;
+    }
+  };
 }
 
 function _extractLatLonBoundingBox(layerEl) {

--- a/static/app.js
+++ b/static/app.js
@@ -29,10 +29,15 @@ const EPSG8857_WORLD_EXTENT = {
  * Build Web Mercator-like zoom resolutions for projected world maps.
  * @param {number} fullWidthMeters - Projected width covered at zoom 0.
  * @param {number} levels - Number of integer zoom levels to define.
+ * @param {number} zoomZeroPixelWidth - Pixel width represented at zoom 0.
  * @returns {number[]} Leaflet/proj4leaflet resolutions from low to high zoom.
  */
-function buildProjectedResolutions(fullWidthMeters, levels = 20) {
-  const zoomZeroResolution = fullWidthMeters / 256;
+function buildProjectedResolutions(
+  fullWidthMeters,
+  levels = 20,
+  zoomZeroPixelWidth = 8192,
+) {
+  const zoomZeroResolution = fullWidthMeters / zoomZeroPixelWidth;
   return Array.from(
     { length: levels },
     (_, zoom) => zoomZeroResolution / Math.pow(2, zoom),

--- a/static/app.js
+++ b/static/app.js
@@ -1229,27 +1229,31 @@ function _findWmsLayerElByName(xml, qualifiedName) {
   return null;
 }
 
-function _extractLayerLatLngBounds(layerEl) {
-  if (!layerEl || !state.map) return null;
-  const crs = state.map.options.crs;
-  const mapCrsCode = String(crs?.code || "").toUpperCase();
+function _isUsableLatLng(latLng) {
+  return (
+    Number.isFinite(latLng?.lat) &&
+    Number.isFinite(latLng?.lng) &&
+    latLng.lat >= -90 &&
+    latLng.lat <= 90 &&
+    latLng.lng >= -360 &&
+    latLng.lng <= 360
+  );
+}
 
-  const bboxEls = _xmlChildren(layerEl, "BoundingBox");
-  for (const bb of bboxEls) {
-    const srs = String(
-      bb.getAttribute("SRS") || bb.getAttribute("CRS") || "",
-    ).toUpperCase();
-    if (!srs || !mapCrsCode || srs !== mapCrsCode) continue;
-    const minx = parseFloat(bb.getAttribute("minx"));
-    const miny = parseFloat(bb.getAttribute("miny"));
-    const maxx = parseFloat(bb.getAttribute("maxx"));
-    const maxy = parseFloat(bb.getAttribute("maxy"));
-    if (![minx, miny, maxx, maxy].every(Number.isFinite)) continue;
-    const sw = crs.unproject(L.point(minx, miny));
-    const ne = crs.unproject(L.point(maxx, maxy));
-    return L.latLngBounds(sw, ne);
-  }
+function _latLngBoundsOrNull(southWest, northEast) {
+  try {
+    const bounds = L.latLngBounds(southWest, northEast);
+    if (
+      _isUsableLatLng(bounds.getSouthWest()) &&
+      _isUsableLatLng(bounds.getNorthEast())
+    ) {
+      return bounds;
+    }
+  } catch {}
+  return null;
+}
 
+function _extractLatLonBoundingBox(layerEl) {
   const ll = _xmlChild(layerEl, "LatLonBoundingBox");
   if (ll) {
     const minx = parseFloat(ll.getAttribute("minx"));
@@ -1257,10 +1261,14 @@ function _extractLayerLatLngBounds(layerEl) {
     const maxx = parseFloat(ll.getAttribute("maxx"));
     const maxy = parseFloat(ll.getAttribute("maxy"));
     if ([minx, miny, maxx, maxy].every(Number.isFinite)) {
-      return L.latLngBounds([miny, minx], [maxy, maxx]);
+      const bounds = _latLngBoundsOrNull([miny, minx], [maxy, maxx]);
+      if (bounds) return bounds;
     }
   }
+  return null;
+}
 
+function _extractGeographicBoundingBox(layerEl) {
   const ex = _xmlChild(layerEl, "EX_GeographicBoundingBox");
   if (ex) {
     const west = parseFloat(
@@ -1276,11 +1284,48 @@ function _extractLayerLatLngBounds(layerEl) {
       String(_xmlChild(ex, "northBoundLatitude")?.textContent || "").trim(),
     );
     if ([west, east, south, north].every(Number.isFinite)) {
-      return L.latLngBounds([south, west], [north, east]);
+      const bounds = _latLngBoundsOrNull([south, west], [north, east]);
+      if (bounds) return bounds;
     }
   }
-
   return null;
+}
+
+function _extractProjectedBoundingBox(layerEl) {
+  if (!state.map) return null;
+  const crs = state.map.options.crs;
+  const mapCrsCode = String(crs?.code || "").toUpperCase();
+
+  const bboxEls = _xmlChildren(layerEl, "BoundingBox");
+  for (const bb of bboxEls) {
+    const srs = String(
+      bb.getAttribute("SRS") || bb.getAttribute("CRS") || "",
+    ).toUpperCase();
+    if (!srs || !mapCrsCode || srs !== mapCrsCode) continue;
+    const minx = parseFloat(bb.getAttribute("minx"));
+    const miny = parseFloat(bb.getAttribute("miny"));
+    const maxx = parseFloat(bb.getAttribute("maxx"));
+    const maxy = parseFloat(bb.getAttribute("maxy"));
+    if (![minx, miny, maxx, maxy].every(Number.isFinite)) continue;
+
+    try {
+      const southWest = crs.unproject(L.point(minx, miny));
+      const northEast = crs.unproject(L.point(maxx, maxy));
+      const bounds = _latLngBoundsOrNull(southWest, northEast);
+      if (bounds) return bounds;
+    } catch {}
+  }
+  return null;
+}
+
+function _extractLayerLatLngBounds(layerEl) {
+  if (!layerEl) return null;
+
+  return (
+    _extractLatLonBoundingBox(layerEl) ||
+    _extractGeographicBoundingBox(layerEl) ||
+    _extractProjectedBoundingBox(layerEl)
+  );
 }
 
 async function _getWmsLayerLatLngBounds(qualifiedName) {


### PR DESCRIPTION
## Summary

Fixes #232.

- Prefer geographic WMS bounds from GetCapabilities before trying CRS-specific projected bounds.
- Validate projected bounds after unprojection so invalid EPSG:8857 conversions are ignored instead of passed to Leaflet.
- Reject low-zoom WMS tile candidates that unproject outside the valid custom projection domain, instead of letting Leaflet crash while checking tile bounds.
- Increase the EPSG:8857 zoom-zero pixel width so normal desktop viewports do not start with pixel origins outside the valid Equal Earth projection domain.
- Avoid sending GeoServer `nativeCRS` WKT when rasterio can identify an EPSG authority code, letting GeoServer use `srs` + `FORCE_DECLARED` instead.
- Update `history.rst`.

## Root cause

The viewer was using the CRS-specific WMS `BoundingBox` first and unprojecting it into Leaflet lat/lng bounds. With EPSG:8857, those bounds could produce invalid lat/lng values such as `NaN`, causing Leaflet to throw during WMS layer creation.

Leaflet can also generate low-zoom candidate WMS tiles outside the valid Equal Earth projection domain before rejecting them against layer bounds. The original EPSG:8857 zoom-zero resolution mapped the full projected world to only 256 pixels, so a typical desktop viewport could place the map pixel origin far outside the projection domain during `layer.addTo(...)`. The CRS now starts from a larger zoom-zero pixel width and still treats invalid tile corner unprojections as invalid tiles.

GeoServer was also receiving rasterio's default WKT2 CRS text for `nativeCRS`, which starts with `PROJCRS[...]`; the GeoServer/GeoTools version in this deployment logs parse errors for that format. Forcing WKT1 is not valid for EPSG:8857 in this GDAL/PROJ stack because Equal Earth cannot be converted to WKT1, so EPSG-authority rasters now omit `nativeCRS` and rely on the declared `srs`.

## Validation

- Frontend production build passed:
  `node node_modules/vite/bin/vite.js build`
- Python syntax check passed:
  `python -m py_compile geoserver_register.py`