### PR TITLE
Use configured workspace for dynamic WMS style

### DIFF
--- a/history.rst
+++ b/history.rst
@@ -12,6 +12,8 @@ Unreleased
   domain from crashing layer creation.
 * Increased the EPSG:8857 zoom-zero pixel width so normal desktop viewports do
   not start outside the valid Equal Earth projection domain.
+* Fixed dynamic WMS styling for deployments that use a workspace other than
+  ``esosc``.
 
 1.5.0 (2026-06-09)
 ------------------

--- a/history.rst
+++ b/history.rst
@@ -3,15 +3,6 @@ History
 
 Unreleased
 ----------
-* Added frontend EPSG:8857 map CRS support and a visible unsupported-CRS
-  startup message.
-* Fixed EPSG:8857 layer startup by preferring geographic WMS bounds in the
-  viewer and avoiding WKT native CRS metadata when GeoServer can use an EPSG
-  authority code during registration.
-* Prevented low-zoom EPSG:8857 WMS tile candidates outside the projection
-  domain from crashing layer creation.
-* Increased the EPSG:8857 zoom-zero pixel width so normal desktop viewports do
-  not start outside the valid Equal Earth projection domain.
 * Fixed dynamic WMS styling for deployments that use a workspace other than
   ``esosc``.
 

--- a/static/app.js
+++ b/static/app.js
@@ -1227,10 +1227,17 @@ async function _getWmsCapsXml() {
 }
 
 function _findWmsLayerElByName(xml, qualifiedName) {
+  const requestedName = String(qualifiedName || "").trim();
   const layers = Array.from(xml.getElementsByTagNameNS("*", "Layer"));
   for (const layerEl of layers) {
     const nameEl = _xmlChild(layerEl, "Name");
-    if (nameEl && String(nameEl.textContent || "").trim() === qualifiedName)
+    if (!nameEl) continue;
+
+    const layerName = String(nameEl.textContent || "").trim();
+    const localLayerName = layerName.includes(":")
+      ? layerName.split(":").pop()
+      : layerName;
+    if (layerName === requestedName || localLayerName === requestedName)
       return layerEl;
   }
   return null;

--- a/static/app.js
+++ b/static/app.js
@@ -1040,6 +1040,7 @@ const layerUnits = (lyr) => {
   const units = lyr?.raster_units ?? lyr?.units;
   return units && String(units).trim() ? String(units).trim() : "";
 };
+const layerWmsName = (lyr) => lyr?.wms_name || lyr?.name;
 
 /**
  * Populate both layer <select> elements, and the base layer, with available
@@ -1175,9 +1176,9 @@ async function onBaseLayerChange(e) {
   let bounds = null;
   try {
     // Fetches WMS capabilities once; later calls read state._wmsLayerBoundsCache.
-    bounds = await _getWmsLayerLatLngBounds(baseLayer.name);
+    bounds = await _getWmsLayerLatLngBounds(layerWmsName(baseLayer));
   } catch {}
-  addWmsLayer(baseLayer.name, "base", {
+  addWmsLayer(layerWmsName(baseLayer), "base", {
     className: "base-layer",
     zIndex: 100,
     bounds,
@@ -1389,10 +1390,11 @@ async function onLayerChange(e, layerId) {
   const lyr = state.availableLayers[idx];
   if (!lyr) return;
   const layerName = lyr.name;
+  const wmsLayerName = layerWmsName(lyr);
   const isCategorical = isCategoricalLayer(lyr);
   const doInitialFit = !state.didInitialRasterFit;
   if (doInitialFit) state.didInitialRasterFit = true;
-  const layerBoundsPromise = _getWmsLayerLatLngBounds(layerName);
+  const layerBoundsPromise = _getWmsLayerLatLngBounds(wmsLayerName);
   renderLayerMeta(layerId, lyr);
   setStyleControlsEnabled(layerId, !isCategorical);
 
@@ -1426,7 +1428,7 @@ async function onLayerChange(e, layerId) {
     } catch {}
   }
   document.getElementById(`layerVisible${layerId}`).checked = true;
-  addWmsLayer(layerName, layerId, { className, bounds });
+  addWmsLayer(wmsLayerName, layerId, { className, bounds });
   if (!isCategorical) applyDynamicStyle(layerId);
   updateContextLegend();
   if (!state.sampleMode) {
@@ -5046,7 +5048,7 @@ function createBaseLegendControl() {
       return;
     }
 
-    const layerName = typeof layer === "string" ? layer : layer.name;
+    const layerName = typeof layer === "string" ? layer : layerWmsName(layer);
     const layerTitle = typeof layer === "string" ? layer : layer.title || layer.name;
     const legendTitle =
       typeof layer === "string"

--- a/static/app.js
+++ b/static/app.js
@@ -18,32 +18,6 @@ const MAX_HISTOGRAM_BINS = 50;
 const MAX_HISTOGRAM_POINTS = 20000;
 const CANADA_CENTER = [55, -96.9];
 const INITIAL_ZOOM = 0;
-const EPSG8857_WORLD_EXTENT = {
-  minX: -17243959.062,
-  minY: -8392927.599,
-  maxX: 17243959.062,
-  maxY: 8392927.599,
-};
-
-/**
- * Build Web Mercator-like zoom resolutions for projected world maps.
- * @param {number} fullWidthMeters - Projected width covered at zoom 0.
- * @param {number} levels - Number of integer zoom levels to define.
- * @param {number} zoomZeroPixelWidth - Pixel width represented at zoom 0.
- * @returns {number[]} Leaflet/proj4leaflet resolutions from low to high zoom.
- */
-function buildProjectedResolutions(
-  fullWidthMeters,
-  levels = 20,
-  zoomZeroPixelWidth = 8192,
-) {
-  const zoomZeroResolution = fullWidthMeters / zoomZeroPixelWidth;
-  return Array.from(
-    { length: levels },
-    (_, zoom) => zoomZeroResolution / Math.pow(2, zoom),
-  );
-}
-
 const CRS3347 = new L.Proj.CRS(
   "EPSG:3347",
   "+proj=lcc +lat_1=49 +lat_2=77 +lat_0=63.390675 +lon_0=-91.8666666666667 +x_0=6200000 +y_0=3000000 +datum=NAD83 +units=m +no_defs",
@@ -54,22 +28,6 @@ const CRS3347 = new L.Proj.CRS(
 );
 // once the new CRS is defined we register it with leaflet's CRS
 L.CRS.EPSG3347 = CRS3347;
-
-const CRS8857 = new L.Proj.CRS(
-  "EPSG:8857",
-  "+proj=eqearth +lon_0=0 +datum=WGS84 +units=m +no_defs +type=crs",
-  {
-    origin: [EPSG8857_WORLD_EXTENT.minX, EPSG8857_WORLD_EXTENT.maxY],
-    bounds: L.bounds(
-      [EPSG8857_WORLD_EXTENT.minX, EPSG8857_WORLD_EXTENT.minY],
-      [EPSG8857_WORLD_EXTENT.maxX, EPSG8857_WORLD_EXTENT.maxY],
-    ),
-    resolutions: buildProjectedResolutions(
-      EPSG8857_WORLD_EXTENT.maxX - EPSG8857_WORLD_EXTENT.minX,
-    ),
-  },
-);
-L.CRS.EPSG8857 = CRS8857;
 
 const state = {
   map: null,
@@ -718,7 +676,7 @@ async function loadConfig() {
 /**
  * Normalize a configured CRS code into a Leaflet CRS registry key.
  * @param {string} crsCode - CRS identifier from app config.
- * @returns {string} CRS key such as EPSG3857 or EPSG8857.
+ * @returns {string} CRS key such as EPSG3857 or EPSG3347.
  */
 function normalizeLeafletCrsKey(crsCode) {
   return String(crsCode).trim().toUpperCase().replace(":", "");
@@ -1141,7 +1099,6 @@ function addWmsLayer(qualifiedName, slot, opts = {}) {
     pane: paneBySlot[slot],
     bounds: opts.bounds ?? null,
   });
-  suppressInvalidProjectedTileBounds(layer);
 
   const stateKey = slot === "base" ? "wmsLayerBase" : `wmsLayer${slot}`;
   if (state[stateKey]) state.map.removeLayer(state[stateKey]);
@@ -1268,31 +1225,6 @@ function _latLngBoundsOrNull(southWest, northEast) {
   return null;
 }
 
-/**
- * Prevent custom projected CRS tile bounds from crashing WMS layer creation.
- *
- * Leaflet checks tile bounds by unprojecting tile corners. At low zoom levels,
- * custom projections such as EPSG:8857 can produce candidate tiles outside the
- * projection's valid domain before Leaflet has a chance to reject them against
- * the layer bounds. Treat those tiles as invalid and let valid tiles continue
- * through Leaflet's normal checks.
- *
- * @param {L.TileLayer.WMS} layer - WMS layer to protect.
- */
-function suppressInvalidProjectedTileBounds(layer) {
-  const originalIsValidTile = layer._isValidTile;
-  layer._isValidTile = function (coords) {
-    try {
-      return originalIsValidTile.call(this, coords);
-    } catch (error) {
-      if (String(error?.message || "").includes("Invalid LatLng object")) {
-        return false;
-      }
-      throw error;
-    }
-  };
-}
-
 function _extractLatLonBoundingBox(layerEl) {
   const ll = _xmlChild(layerEl, "LatLonBoundingBox");
   if (ll) {
@@ -1331,61 +1263,13 @@ function _extractGeographicBoundingBox(layerEl) {
   return null;
 }
 
-function _extractProjectedBoundingBox(layerEl) {
-  if (!state.map) return null;
-  const crs = state.map.options.crs;
-  const mapCrsCode = String(crs?.code || "").toUpperCase();
-
-  const bboxEls = _xmlChildren(layerEl, "BoundingBox");
-  for (const bb of bboxEls) {
-    const srs = String(
-      bb.getAttribute("SRS") || bb.getAttribute("CRS") || "",
-    ).toUpperCase();
-    if (!srs || !mapCrsCode || srs !== mapCrsCode) continue;
-    const minx = parseFloat(bb.getAttribute("minx"));
-    const miny = parseFloat(bb.getAttribute("miny"));
-    const maxx = parseFloat(bb.getAttribute("maxx"));
-    const maxy = parseFloat(bb.getAttribute("maxy"));
-    if (![minx, miny, maxx, maxy].every(Number.isFinite)) continue;
-
-    try {
-      const southWest = crs.unproject(L.point(minx, miny));
-      const northEast = crs.unproject(L.point(maxx, maxy));
-      const bounds = _latLngBoundsOrNull(southWest, northEast);
-      if (bounds) return bounds;
-    } catch {}
-  }
-  return null;
-}
-
 function _extractLayerLatLngBounds(layerEl) {
   if (!layerEl) return null;
 
   return (
     _extractLatLonBoundingBox(layerEl) ||
-    _extractGeographicBoundingBox(layerEl) ||
-    _extractProjectedBoundingBox(layerEl)
+    _extractGeographicBoundingBox(layerEl)
   );
-}
-
-function _nextAnimationFrame() {
-  return new Promise((resolve) => window.requestAnimationFrame(resolve));
-}
-
-async function fitInitialRasterBounds(bounds) {
-  if (!bounds?.isValid?.()) return false;
-
-  await _nextAnimationFrame();
-  await _nextAnimationFrame();
-  state.map.invalidateSize({ pan: false });
-  state.map.fitBounds(bounds, { padding: [24, 24], animate: false });
-
-  state.lastMouseLatLng = state.map.getCenter();
-  if (state.hoverRect) {
-    const poly = squarePolygonAt(state.lastMouseLatLng, state.boxSizeKm);
-    state.hoverRect.setLatLngs(poly.getLatLngs());
-  }
-  return true;
 }
 
 async function _getWmsLayerLatLngBounds(qualifiedName) {
@@ -1465,7 +1349,8 @@ async function onLayerChange(e, layerId) {
   history.replaceState(null, "", url.toString());
   if (!state.didInitialRasterFit && bounds) {
     try {
-      if (await fitInitialRasterBounds(bounds)) {
+      if (bounds.isValid()) {
+        state.map.fitBounds(bounds, { padding: [24, 24] });
         state.didInitialRasterFit = true;
       }
     } catch {}

--- a/static/app.js
+++ b/static/app.js
@@ -75,6 +75,7 @@ const state = {
   map: null,
   geoserverBaseUrl: null,
   baseStatsUrl: null,
+  dynamicStyle: "esosc:dynamic_style",
   wmsLayerA: null,
   wmsLayerB: null,
   availableLayers: null,
@@ -2249,7 +2250,7 @@ function applyDynamicStyle(layerId) {
     const styleVars = readStyleInputsFromUI(layerId);
     const env = buildEnvString(styleVars);
 
-    layer.setParams({ styles: "esosc:dynamic_style", env, _t: Date.now() });
+    layer.setParams({ styles: state.dynamicStyle, env, _t: Date.now() });
   }
   renderBivariateLegend();
 }
@@ -5105,6 +5106,7 @@ function createBaseLegendControl() {
   state.availableLayers = cfg.layers;
   state.availableBaseLayers = cfg.baseLayers || [];
   state.baseStatsUrl = cfg.rstats_base_url;
+  state.dynamicStyle = cfg.dynamic_style || state.dynamicStyle;
 
   initMap(cfg.global_crs);
   wireSquareSamplerControls();

--- a/static/app.js
+++ b/static/app.js
@@ -1368,6 +1368,26 @@ function _extractLayerLatLngBounds(layerEl) {
   );
 }
 
+function _nextAnimationFrame() {
+  return new Promise((resolve) => window.requestAnimationFrame(resolve));
+}
+
+async function fitInitialRasterBounds(bounds) {
+  if (!bounds?.isValid?.()) return false;
+
+  await _nextAnimationFrame();
+  await _nextAnimationFrame();
+  state.map.invalidateSize({ pan: false });
+  state.map.fitBounds(bounds, { padding: [24, 24], animate: false });
+
+  state.lastMouseLatLng = state.map.getCenter();
+  if (state.hoverRect) {
+    const poly = squarePolygonAt(state.lastMouseLatLng, state.boxSizeKm);
+    state.hoverRect.setLatLngs(poly.getLatLngs());
+  }
+  return true;
+}
+
 async function _getWmsLayerLatLngBounds(qualifiedName) {
   if (!qualifiedName) return null;
   if (state._wmsLayerBoundsCache.has(qualifiedName))
@@ -1445,8 +1465,7 @@ async function onLayerChange(e, layerId) {
   history.replaceState(null, "", url.toString());
   if (!state.didInitialRasterFit && bounds) {
     try {
-      if (bounds.isValid()) {
-        state.map.fitBounds(bounds, { padding: [24, 24] });
+      if (await fitInitialRasterBounds(bounds)) {
         state.didInitialRasterFit = true;
       }
     } catch {}

--- a/static/app.js
+++ b/static/app.js
@@ -1392,8 +1392,6 @@ async function onLayerChange(e, layerId) {
   const layerName = lyr.name;
   const wmsLayerName = layerWmsName(lyr);
   const isCategorical = isCategoricalLayer(lyr);
-  const doInitialFit = !state.didInitialRasterFit;
-  if (doInitialFit) state.didInitialRasterFit = true;
   const layerBoundsPromise = _getWmsLayerLatLngBounds(wmsLayerName);
   renderLayerMeta(layerId, lyr);
   setStyleControlsEnabled(layerId, !isCategorical);
@@ -1445,9 +1443,12 @@ async function onLayerChange(e, layerId) {
   const url = new URL(window.location.href);
   url.searchParams.set(`layer${layerId}`, layerName);
   history.replaceState(null, "", url.toString());
-  if (doInitialFit && bounds) {
+  if (!state.didInitialRasterFit && bounds) {
     try {
-      if (bounds.isValid()) state.map.fitBounds(bounds, { padding: [24, 24] });
+      if (bounds.isValid()) {
+        state.map.fitBounds(bounds, { padding: [24, 24] });
+        state.didInitialRasterFit = true;
+      }
     } catch {}
   }
 }

--- a/static/app.js
+++ b/static/app.js
@@ -75,7 +75,7 @@ const state = {
   map: null,
   geoserverBaseUrl: null,
   baseStatsUrl: null,
-  dynamicStyle: "esosc:dynamic_style",
+  dynamicStyle: null,
   wmsLayerA: null,
   wmsLayerB: null,
   availableLayers: null,
@@ -5106,7 +5106,10 @@ function createBaseLegendControl() {
   state.availableLayers = cfg.layers;
   state.availableBaseLayers = cfg.baseLayers || [];
   state.baseStatsUrl = cfg.rstats_base_url;
-  state.dynamicStyle = cfg.dynamic_style || state.dynamicStyle;
+  state.dynamicStyle = cfg.dynamic_style;
+  if (!state.dynamicStyle) {
+    throw new Error("Viewer config is missing dynamic_style.");
+  }
 
   initMap(cfg.global_crs);
   wireSquareSamplerControls();

--- a/viewer_app/main.py
+++ b/viewer_app/main.py
@@ -125,18 +125,6 @@ def _sample_vector_config(config: dict) -> Optional[dict]:
     }
 
 
-def _dynamic_style_name(config: dict) -> str:
-    """Return the fully qualified dynamic style name for WMS requests.
-
-    Args:
-        config (dict): Loaded layers YAML configuration.
-
-    Returns:
-        str: Workspace-qualified style name such as ``"esosc:dynamic_style"``.
-    """
-    return f"{config['workspace_id']}:{Path(config['style_path']).stem}"
-
-
 def _read_version():
     """Return the application version from environment or a baked file.
 
@@ -229,5 +217,5 @@ def api_config():
         "sampleVector": _sample_vector_config(config),
         "rstats_base_url": os.getenv("RSTATS_BASE_URL").strip(),
         "global_crs": os.getenv("GLOBAL_CRS").strip(),
-        "dynamic_style": _dynamic_style_name(config),
+        "dynamic_style": f"{config['workspace_id']}:{Path(config['style_path']).stem}",
     }

--- a/viewer_app/main.py
+++ b/viewer_app/main.py
@@ -103,6 +103,7 @@ def _collect_layers(layer_key: str, config: dict) -> list:
                 "workspace": workspace_id,
                 # we push this lower because geoserver lowercases all ids
                 "name": Path(layer["file_path"]).stem.lower(),
+                "wms_name": f"{workspace_id}:{Path(layer['file_path']).stem.lower()}",
                 "title": layer.get("title"),
                 "description": layer.get("description"),
                 "raster_units": raster_units,

--- a/viewer_app/main.py
+++ b/viewer_app/main.py
@@ -217,5 +217,5 @@ def api_config():
         "sampleVector": _sample_vector_config(config),
         "rstats_base_url": os.getenv("RSTATS_BASE_URL").strip(),
         "global_crs": os.getenv("GLOBAL_CRS").strip(),
-        "dynamic_style": f"{config['workspace_id']}:{Path(config['style_path']).stem}",
+        "dynamic_style": Path(config["style_path"]).stem,
     }

--- a/viewer_app/main.py
+++ b/viewer_app/main.py
@@ -125,6 +125,18 @@ def _sample_vector_config(config: dict) -> Optional[dict]:
     }
 
 
+def _dynamic_style_name(config: dict) -> str:
+    """Return the fully qualified dynamic style name for WMS requests.
+
+    Args:
+        config (dict): Loaded layers YAML configuration.
+
+    Returns:
+        str: Workspace-qualified style name such as ``"esosc:dynamic_style"``.
+    """
+    return f"{config['workspace_id']}:{Path(config['style_path']).stem}"
+
+
 def _read_version():
     """Return the application version from environment or a baked file.
 
@@ -217,4 +229,5 @@ def api_config():
         "sampleVector": _sample_vector_config(config),
         "rstats_base_url": os.getenv("RSTATS_BASE_URL").strip(),
         "global_crs": os.getenv("GLOBAL_CRS").strip(),
+        "dynamic_style": _dynamic_style_name(config),
     }


### PR DESCRIPTION
## Summary

Fixes #234.

- Add `dynamic_style` to `/api/config`, derived from `workspace_id` and `style_path` in the YAML config.
- Store the configured style name in frontend state.
- Use that configured style for dynamic WMS styling instead of hard-coded `esosc:dynamic_style`.
- Update `history.rst`.

## Root cause

The GeoServer init service creates the dynamic style in the configured workspace. For the GEP deployment, that style is `gep:dynamic_style`, but the viewer still requested `esosc:dynamic_style`, producing GeoServer WMS errors and blank/error tiles.

## Validation

- Frontend production build passed:
  `node node_modules/vite/bin/vite.js build`
- Python syntax check passed:
  `python -m py_compile viewer_app/main.py`